### PR TITLE
[Backport][ipa-4-6] Disallow retrieving software versions

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -1,5 +1,5 @@
 #
-# VERSION 28 - DO NOT REMOVE THIS LINE
+# VERSION 29 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -54,6 +54,9 @@ WSGIImportScript /usr/share/ipa/wsgi.py process-group=ipa application-group=ipa
 WSGIScriptAlias /ipa /usr/share/ipa/wsgi.py
 WSGIScriptReloading Off
 
+# Disallow sniffing server software versions
+ServerSignature Off
+ServerTokens Prod
 
 # Turn off mod_msgi handler for errors, config, crl:
 <Location "/ipa/errors">


### PR DESCRIPTION
Manual backport of: https://github.com/freeipa/freeipa/pull/8335

Fixes: https://pagure.io/freeipa/issue/9897

## Summary by Sourcery

Enhancements:
- Disable server signature and restrict server tokens in Apache config to prevent exposing detailed software version information.