### PR TITLE
ipatests: adapt the expected output message

### DIFF
--- a/ipatests/test_integration/test_trust_functional.py
+++ b/ipatests/test_integration/test_trust_functional.py
@@ -1868,7 +1868,7 @@ class TestTrustFunctionalUser(BaseTestTrust):
                 )
                 output = result.stdout_text.strip()
                 # whoami returns fully qualified name for AD trust users
-                assert output == f'{username}@{domain}'
+                assert f'{username}@{domain}' in output
 
     def test_passwd_change_by_user(self):
         """


### PR DESCRIPTION
The test test_trust_functional.py::TestTrustFunctionalUser::test_su_ad_user
is performing "su - nonposixuser@AD.TEST -c whoami" in a trust env
and expects an exact output.

With util-linux-2.42-7.fc45 the output also contains a line with
    Last login: $DATE from $IP_ADDR on ssh

The test needs to be more flexible and check that the output contains
the username, not that it is strictly equal to the username

Fixes: https://pagure.io/freeipa/issue/9980
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>

## Summary by Sourcery

Relax AD trust whoami output assertion and extend CI coverage for trust functional tests on Fedora latest and rawhide.

CI:
- Add dedicated trust functional AD test jobs for Fedora latest and rawhide with appropriate topologies and timeouts.

Tests:
- Update trust functional test to accept whoami output that contains the AD username rather than matching it exactly.