### PR TITLE
KDB: fix LDAP encoding of tl_data

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_common.c
+++ b/daemons/ipa-kdb/ipa_kdb_common.c
@@ -517,7 +517,13 @@ int ipadb_ldap_attr_to_strlist(LDAP *lcontext, LDAPMessage *le,
     }
 
     for (i = 0; vals[i]; i++) {
-        strlist[i] = strndup(vals[i]->bv_val, vals[i]->bv_len);
+        size_t len = vals[i]->bv_len;
+
+        /* Trim trailing null terminator if present (backwards compatibility) */
+        if (len > 0 && vals[i]->bv_val[len - 1] == '\0')
+            --len;
+
+        strlist[i] = strndup(vals[i]->bv_val, len);
         if (!strlist[i]) {
             ret = ENOMEM;
             goto fail;

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -139,6 +139,12 @@ static int ipadb_ldap_attr_to_tl_data(LDAP *lcontext, LDAPMessage *le,
     vals = ldap_get_values_len(lcontext, le, attrname);
     if (vals) {
         for (i = 0; vals[i]; i++) {
+            /* There should be at least 2 bytes encoding the tl_data type. */
+            if (vals[i]->bv_len < 2) {
+                ret = EINVAL;
+                goto done;
+            }
+
             next = calloc(1, sizeof(krb5_tl_data));
             if (!next) {
                 ret = ENOMEM;

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -2681,7 +2681,7 @@ static krb5_error_code ipadb_get_ldap_mod_str_list(struct ipadb_mods *imods,
             kerr = ENOMEM;
             goto done;
         }
-        bvs[i]->bv_len = strlen(strlist[i]) + 1;
+        bvs[i]->bv_len = strlen(strlist[i]);
     }
 
     kerr = ipadb_get_ldap_mod_bvalues(imods, attrname, bvs, len, mod_op);


### PR DESCRIPTION
## Summary by Sourcery

Validate and normalize LDAP tl_data encoding to avoid including type bytes or null terminators in stored tl_data values.

Bug Fixes:
- Reject malformed LDAP tl_data entries that are shorter than the required type header.
- Strip trailing string null terminators from tl_data contents before storing them.
- Stop counting and sending string null terminators in LDAP modification values for tl_data-related attributes.