### PR TITLE
ipatests: fix dnszone_add SOA MNAME expectation for numeric TLD

### DIFF
--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -6710,7 +6710,7 @@ class test_dns_soa(Declarative):
                              api.env.container_dns, api.env.basedn),
                     'idnsname': [DNSName(u'domain.numeric.123.')],
                     'idnszoneactive': [True],
-                    'idnssoamname': [DNSName(api.env.host)],
+                    'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': lambda x: True,
                     'idnssoarname': lambda x: True,
                     'idnssoaserial': [fuzzy_digits],


### PR DESCRIPTION
The API returns idnssoamname as a fully qualified name (trailing dot). Use self_server_ns_dnsname like the other dnszone_add tests, not DNSName(api.env.host) without normalization.


Related: https://pagure.io/freeipa/issue/9911
Signed-off-by: Pranav Thube pthube@redhat.com

## Summary by Sourcery

Bug Fixes:
- Correct the dnszone_add test expectation for SOA MNAME to use the normalized server NS DNS name for numeric TLD zones.