### PR TITLE
ipatests: Change the xfail version to sssd 2.12.0

### DIFF
--- a/ipatests/test_integration/test_trust_functional.py
+++ b/ipatests/test_integration/test_trust_functional.py
@@ -2143,12 +2143,12 @@ class TestTrustFunctionalUser(BaseTestTrust):
                     )
                 time.sleep(60)
 
-                # Test on client: xfail on Fedora when SSSD is 2.12.0 or older
+                # Test on client: xfail on Fedora when SSSD is 2.12.0
                 client = self.clients[0]
                 with xfail_context(
                     osinfo.id == 'fedora'
                     and tasks.get_sssd_version(client)
-                    <= parse_version('2.12.0'),
+                    == parse_version('2.12.0'),
                     reason=(
                         "Fix available after 2.12.0; "
                         "https://github.com/SSSD/sssd/issues/8441"


### PR DESCRIPTION
The regression was introduced in 2.12.0, we can't xfail older versions. For more details see: https://github.com/SSSD/sssd/pull/8442

Fixes: https://pagure.io/freeipa/issue/9981

## Summary by Sourcery

Tests:
- Narrow the xfail condition in the trust functional integration test to only SSSD version 2.12.0 on Fedora.