### PR TITLE
[Backport][ipa-4-12] ipatests: adapt the expected output message

### DIFF
--- a/ipatests/test_integration/test_trust_functional.py
+++ b/ipatests/test_integration/test_trust_functional.py
@@ -1868,7 +1868,7 @@ class TestTrustFunctionalUser(BaseTestTrust):
                 )
                 output = result.stdout_text.strip()
                 # whoami returns fully qualified name for AD trust users
-                assert output == f'{username}@{domain}'
+                assert f'{username}@{domain}' in output
 
     def test_passwd_change_by_user(self):
         """


### PR DESCRIPTION
This PR was opened automatically because PR #8371 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Tests:
- Update the trust functional integration test to assert that whoami output contains username@domain rather than matching it exactly.