### PR TITLE
[Backport][ipa-4-12] ipatests: Change the xfail version to sssd 2.12.0

### DIFF
--- a/ipatests/test_integration/test_trust_functional.py
+++ b/ipatests/test_integration/test_trust_functional.py
@@ -2143,12 +2143,12 @@ class TestTrustFunctionalUser(BaseTestTrust):
                     )
                 time.sleep(60)
 
-                # Test on client: xfail on Fedora when SSSD is 2.12.0 or older
+                # Test on client: xfail on Fedora when SSSD is 2.12.0
                 client = self.clients[0]
                 with xfail_context(
                     osinfo.id == 'fedora'
                     and tasks.get_sssd_version(client)
-                    <= parse_version('2.12.0'),
+                    == parse_version('2.12.0'),
                     reason=(
                         "Fix available after 2.12.0; "
                         "https://github.com/SSSD/sssd/issues/8441"


### PR DESCRIPTION
This PR was opened automatically because PR #8379 was pushed to master and backport to ipa-4-12 is required.

## Summary by Sourcery

Tests:
- Restrict xfail condition to Fedora environments running exactly SSSD 2.12.0 in a trust functional integration test.