### PR TITLE
[Backport][ipa-4-13] fix: change ModifyLDIF modification processing logic for proper Schema Compat turn off

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -1384,7 +1384,8 @@ class ModifyLDIF(ldif.LDIFParser):
         self.writer = ldif.LDIFWriter(output_file)
         self.dn_updated = set()
 
-        self.modifications = {}  # keep modify operations in original order
+        # keep modify operations in original order
+        self.modifications = ipautil.CIDict()
 
     def add_value(self, dn, attr, values):
         """
@@ -1502,10 +1503,14 @@ class ModifyLDIF(ldif.LDIFParser):
         ldif.LDIFParser.parse(self)
 
         # check if there are any remaining modifications
-        remaining_changes = set(self.modifications.keys()) - self.dn_updated
-        for dn in remaining_changes:
+        updated_lower = set(dn.lower() for dn in self.dn_updated)
+        mods_lower = set(dn.lower() for dn in self.modifications)
+        remaining_modifications = mods_lower - updated_lower
+
+        for dn in remaining_modifications:
             logger.error(
-                "DN: %s does not exists or haven't been updated", dn)
+                "DN: %s does not exist or hasn't been updated", dn
+            )
 
 
 def remove_keytab(keytab_path):

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -17,6 +17,7 @@ import pytest
 
 from ipaplatform.paths import paths
 from ipapython.dn import DN
+from ipapython.ipaldap import realm_to_serverid
 from ipapython.ipautil import template_str
 from ipaserver.install import bindinstance
 from ipaserver.install.sysupgrade import STATEFILE_FILE
@@ -197,10 +198,34 @@ class TestUpgrade(IntegrationTest):
             self.master.run_command(['ipa', 'location-del', location])
 
     def test_invoke_upgrader(self):
-        cmd = self.master.run_command(['ipa-server-upgrade'],
-                                      raiseonerr=False)
-        assert ("DN: cn=Schema Compatibility,cn=plugins,cn=config does not \
-                exists or haven't been updated" not in cmd.stdout_text)
+        """Test that ipa-server-upgrade handles DN case mismatch in dse.ldif.
+
+        ModifyLDIF must match DNs case-insensitively so that a DN stored
+        in dse.ldif with different capitalisation
+        (e.g. after update from old IPA version)
+        is still updated correctly during upgrade.
+        """
+        instance = realm_to_serverid(self.master.domain.realm)
+        dse_ldif = (paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance
+                    + "/dse.ldif")
+
+        self.master.run_command(['ipactl', 'stop'])
+        self.master.run_command([
+            'sed', '-i',
+            r's/^dn: cn=Schema Compatibility,cn=plugins,cn=config/'
+            r'dn: cn=SCHEMA comPatIbilIty,cn=plugins,cn=config/',
+            dse_ldif,
+        ])
+        self.master.run_command(['ipactl', 'start'])
+        cmd = self.master.run_command(
+            ['ipa-server-upgrade'],
+            raiseonerr=False,
+        )
+        assert (
+            "cn=Schema Compatibility,cn=plugins,cn=config "
+            "does not exists or haven't been updated"
+            not in cmd.stdout_text
+        )
         assert cmd.returncode == 0
 
     def test_double_encoded_cacert(self):


### PR DESCRIPTION
This PR was opened automatically because PR #8374 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Handle case-insensitive DN matching in ModifyLDIF processing and add an integration test to verify ipa-server-upgrade correctly updates the Schema Compatibility plugin entry.

Bug Fixes:
- Ensure ModifyLDIF tracks and matches DNs case-insensitively so schema compatibility entries in dse.ldif are correctly updated during upgrade.
- Fix the error message emitted for unmodified DNs to use correct spelling and wording.

Tests:
- Extend ipa-server-upgrade integration tests to cover upgrades when the Schema Compatibility DN in dse.ldif has different capitalisation.