### PR TITLE
[Backport][ipa-4-13] ipatests: fix dnszone_add SOA MNAME expectation for numeric TLD

### DIFF
--- a/ipatests/test_xmlrpc/test_dns_plugin.py
+++ b/ipatests/test_xmlrpc/test_dns_plugin.py
@@ -6710,7 +6710,7 @@ class test_dns_soa(Declarative):
                              api.env.container_dns, api.env.basedn),
                     'idnsname': [DNSName(u'domain.numeric.123.')],
                     'idnszoneactive': [True],
-                    'idnssoamname': [DNSName(api.env.host)],
+                    'idnssoamname': [self_server_ns_dnsname],
                     'nsrecord': lambda x: True,
                     'idnssoarname': lambda x: True,
                     'idnssoaserial': [fuzzy_digits],


### PR DESCRIPTION
This PR was opened automatically because PR #8378 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Bug Fixes:
- Update dnszone_add test to expect the server NS DNS name instead of the host name as the SOA MNAME for numeric TLD zones.