### PR TITLE
constants: Use 24-byte key to check id TripleDES is supported

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -405,5 +405,5 @@ VAULT_WRAPPING_DEFAULT_ALGO = VAULT_WRAPPING_AES128_CBC
 
 # Add 3DES for backwards compatibility if supported
 if backend.cipher_supported(TripleDES(
-                            b"\x00" * 8), modes.CBC(b"\x00" * 8)):
+                            b"\x00" * 24), modes.CBC(b"\x00" * 8)):
     VAULT_WRAPPING_SUPPORTED_ALGOS += (VAULT_WRAPPING_3DES,)

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -152,7 +152,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   fedora-latest/test_idm_api:

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -144,7 +144,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   fedora-latest/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -69,7 +69,7 @@ jobs:
         copr: '@389ds/389-ds-base-nightly'
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   389ds-fedora/test_server_del:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -151,7 +151,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   fedora-latest/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -63,7 +63,7 @@ jobs:
         copr: '@sssd/nightly'
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   sssd-fedora/test_external_idp:

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -159,7 +159,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   testing-fedora/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -166,7 +166,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_commands.py
         template: *ci-master-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   testing-fedora/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -144,7 +144,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-master-previous
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   fedora-previous/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -150,7 +150,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_commands.py
         template: *ci-master-frawhide
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   fedora-rawhide/test_kerberos_flags:


### PR DESCRIPTION
The ipalib module checks if TripleDES is still supported by
initializing an instance with a 8-byte key.
With python3-cryptography 47, only 24-byte keys are supported and
the module raises a DeprecationWarning.

Use a 24-byte key instead.

Fixes: https://pagure.io/freeipa/issue/9983

## Summary by Sourcery

Update TripleDES support check to use a 24-byte key and expand CI coverage for integration command tests on Fedora latest and rawhide.

Bug Fixes:
- Prevent deprecation warnings by using a 24-byte key when probing TripleDES support in ipalib constants.

Tests:
- Run integration test_commands suite on Fedora latest and add a new Fedora rawhide job that builds and runs the same suite.