### PR TITLE
[Backport][ipa-4-8] Enforce Same-Site cookie

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 33 - DO NOT REMOVE THIS LINE
+# VERSION 34 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -69,7 +69,7 @@ ServerTokens Prod
   AuthName "Kerberos Login"
   GssapiUseSessions On
   Session On
-  SessionCookieName ipa_session path=/ipa;httponly;secure;
+  SessionCookieName ipa_session path=/ipa;httponly;secure;SameSite=strict;
   SessionHeader IPASESSION
   # Uncomment the following to have shorter sessions, but beware this may break
   # old IPA client tols that incorrectly parse cookies.
@@ -131,7 +131,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
 
   GssapiUseSessions On
   Session On
-  SessionCookieName ipa_session path=/ipa;httponly;secure;
+  SessionCookieName ipa_session path=/ipa;httponly;secure;SameSite=strict;
   SessionHeader IPASESSION
   SessionMaxAge 1800
   GssapiSessionKey file:$GSSAPI_SESSION_KEY


### PR DESCRIPTION
Manual backport of: https://github.com/freeipa/freeipa/pull/8336

Fixes: https://pagure.io/freeipa/issue/9749

## Summary by Sourcery

Bug Fixes:
- Align web server configuration with upstream changes to enforce correct SameSite cookie behaviour.