### PR TITLE
[Backport][ipa-4-6] Enforce Same-Site cookie

### DIFF
--- a/install/conf/ipa.conf
+++ b/install/conf/ipa.conf
@@ -1,5 +1,5 @@
 #
-# VERSION 29 - DO NOT REMOVE THIS LINE
+# VERSION 30 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -75,7 +75,7 @@ ServerTokens Prod
   AuthName "Kerberos Login"
   GssapiUseSessions On
   Session On
-  SessionCookieName ipa_session path=/ipa;httponly;secure;
+  SessionCookieName ipa_session path=/ipa;httponly;secure;SameSite=strict;
   SessionHeader IPASESSION
   # Uncomment the following to have shorter sessions, but beware this may break
   # old IPA client tols that incorrectly parse cookies.
@@ -127,7 +127,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
 
   GssapiUseSessions On
   Session On
-  SessionCookieName ipa_session path=/ipa;httponly;secure;
+  SessionCookieName ipa_session path=/ipa;httponly;secure;SameSite=strict;
   SessionHeader IPASESSION
   SessionMaxAge 1800
   GssapiSessionKey file:/etc/httpd/alias/ipasession.key


### PR DESCRIPTION
Manual backport of: https://github.com/freeipa/freeipa/pull/8336

Fixes: https://pagure.io/freeipa/issue/9749

## Summary by Sourcery

Enhancements:
- Update Apache IPA configuration to mark ipa_session cookies with SameSite=strict for improved session isolation and security.