### PR TITLE
replica conncheck: use crypto-policies in temp krb5.conf

### DIFF
--- a/install/tools/ipa-replica-conncheck.in
+++ b/install/tools/ipa-replica-conncheck.in
@@ -237,7 +237,11 @@ def configure_krb5_conf(realm, kdc, filename):
     krbconf.setSubSectionDelimiters(("{","}"))
     krbconf.setIndent(("","  ","    "))
 
-    opts = [{'name':'comment', 'type':'comment', 'value':'File created by ipa-replica-conncheck'},
+    opts = [{'name':'comment', 'type':'comment',
+             'value':'File created by ipa-replica-conncheck'},
+            {'name':'empty', 'type':'empty'},
+            {'name':'include', 'type':'option', 'delim':' ',
+             'value':'/etc/krb5.conf.d/crypto-policies'},
             {'name':'empty', 'type':'empty'}]
 
     #[libdefaults]


### PR DESCRIPTION
ipa-replica-conncheck creates a temporary krb5.conf file in order to obtain a kerberos ticket with the master and launch server_conncheck on the master via IPA API.

When the master is a RHEL 8.10 machine in FIPS mode, the call to kinit fails because the replica and master don't have any common encryption type.

Modify the temp krb5.conf file to also include
/etc/krb5.conf.d/crypto-policies to guarantee common enc types.

Fixes: https://pagure.io/freeipa/issue/9989
## Summary by Sourcery

Bug Fixes:
- Resolve kinit failures in FIPS mode by including crypto-policies Kerberos configuration in the temporary krb5.conf used by ipa-replica-conncheck.