### PR TITLE
Increase the AJP proxy buffer size to handle large certificates

### DIFF
--- a/install/share/ipa-pki-proxy.conf.template
+++ b/install/share/ipa-pki-proxy.conf.template
@@ -1,5 +1,7 @@
 # VERSION 18 - DO NOT REMOVE THIS LINE
 
+# Do not customise this file; it gets rewritten on every upgrade
+
 ProxyRequests Off
 
 $DOGTAG_AJP_PACKET_SIZE

--- a/install/share/ipa-pki-proxy.conf.template
+++ b/install/share/ipa-pki-proxy.conf.template
@@ -1,6 +1,8 @@
-# VERSION 17 - DO NOT REMOVE THIS LINE
+# VERSION 18 - DO NOT REMOVE THIS LINE
 
 ProxyRequests Off
+
+$DOGTAG_AJP_PACKET_SIZE
 
 # matches for ee port
 <LocationMatch "^/ca/ee/ca/checkRequest|^/ca/ee/ca/getCertChain|^/ca/ee/ca/getTokenInfo|^/ca/ee/ca/tokenAuthenticate|^/ca/ocsp|^/ca/ee/ca/updateNumberRange|^/ca/ee/ca/getCRL|^/ca/ee/ca/profileSubmit">

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -1178,7 +1178,6 @@ class CAInstance(DogtagInstance):
 
         return publishdir
 
-
     def __enable_crl_publish(self):
         """
         Enable file-based CRL publishing and disable LDAP publishing.

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -489,8 +489,39 @@ class DogtagInstance(service.Service):
 
         return rewrite
 
+    def get_ajp_packet_size(self):
+        """Return packetSize if set in the AJP connectors
+
+           There are multiple connectors but the value should be the same.
+
+           We aren't trying to keep the values in sync between PKI and
+           Apache. They should both be 65536.
+
+           There are several opportunities for a user to mess this up:
+           * the attribute name is case-sensitive
+           * we only want the max possible value, nothing creative
+
+           Return the value if set, None if not.
+        """
+
+        server_xml = lxml.etree.parse(paths.PKI_TOMCAT_SERVER_XML)
+        doc = server_xml.getroot()
+
+        # no AJP connector is probably bad.
+        connectors = doc.xpath('//Connector[@protocol="AJP/1.3"]')
+        if len(connectors) == 0:
+            logger.debug("No AJP connectors found in get_ajp_packet_size")
+            return None
+
+        for connector in connectors:
+            if 'packetSize' in connector.attrib:
+                return connector.get('packetSize')
+
+        return None
+
     def http_proxy(self):
         """ Update the http proxy file  """
+        ajp_packet_size = self.get_ajp_packet_size()
         template_filename = (
             os.path.join(paths.USR_SHARE_IPA_DIR,
                          "ipa-pki-proxy.conf.template"))
@@ -499,9 +530,14 @@ class DogtagInstance(service.Service):
             CLONE='' if self.clone else '#',
             FQDN=self.fqdn,
             DOGTAG_AJP_SECRET='',
+            DOGTAG_AJP_PACKET_SIZE='',
         )
         if self.ajp_secret:
             sub_dict['DOGTAG_AJP_SECRET'] = "secret={}".format(self.ajp_secret)
+        if ajp_packet_size:
+            sub_dict['DOGTAG_AJP_PACKET_SIZE'] = (
+                "ProxyIOBufferSize {}".format(ajp_packet_size)
+            )
         template = ipautil.template_file(template_filename, sub_dict)
         with open(paths.HTTPD_IPA_PKI_PROXY_CONF, "w") as fd:
             fd.write(template)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1732,21 +1732,27 @@ def upgrade_configuration():
                 ca.add_ipa_wait()
 
             # Handle upgrade of AJP connector configuration
-            rewrite = ca.secure_ajp_connector()
+            secret_needs_sync = ca.secure_ajp_connector()
             if ca.ajp_secret:
                 sub_dict['DOGTAG_AJP_SECRET'] = "secret={}".format(
                     ca.ajp_secret)
             else:
                 sub_dict['DOGTAG_AJP_SECRET'] = ''
 
+            ajp_packet_size = ca.get_ajp_packet_size()
+            if ajp_packet_size:
+                sub_dict['DOGTAG_AJP_PACKET_SIZE'] = (
+                    "ProxyIOBufferSize {}".format(ajp_packet_size))
+            else:
+                sub_dict['DOGTAG_AJP_PACKET_SIZE'] = ''
+
             # force=True will ensure the secret is updated if it changes
-            if rewrite:
-                upgrade_file(
-                    sub_dict,
-                    paths.HTTPD_IPA_PKI_PROXY_CONF,
-                    os.path.join(paths.USR_SHARE_IPA_DIR,
-                                 "ipa-pki-proxy.conf.template"),
-                    add=True, force=True)
+            upgrade_file(
+                sub_dict,
+                paths.HTTPD_IPA_PKI_PROXY_CONF,
+                os.path.join(paths.USR_SHARE_IPA_DIR,
+                             "ipa-pki-proxy.conf.template"),
+                add=True, force=secret_needs_sync)
         else:
             if os.path.isfile(paths.HTTPD_IPA_PKI_PROXY_CONF):
                 os.remove(paths.HTTPD_IPA_PKI_PROXY_CONF)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1732,7 +1732,7 @@ def upgrade_configuration():
                 ca.add_ipa_wait()
 
             # Handle upgrade of AJP connector configuration
-            secret_needs_sync = ca.secure_ajp_connector()
+            ca.secure_ajp_connector()
             if ca.ajp_secret:
                 sub_dict['DOGTAG_AJP_SECRET'] = "secret={}".format(
                     ca.ajp_secret)
@@ -1746,13 +1746,21 @@ def upgrade_configuration():
             else:
                 sub_dict['DOGTAG_AJP_PACKET_SIZE'] = ''
 
-            # force=True will ensure the secret is updated if it changes
+            # There are several conditions that require the updating
+            # of ipa-pki-proxy.conf, in addition to version bump:
+            #
+            # - AJP secret added or changed
+            # - Dogtag AJP packet size added or changed
+            #
+            # Forcing a rewrite on every upgrade avoids the complexity
+            # to check for these conditions.  Therefore: force=True
+            #
             upgrade_file(
                 sub_dict,
                 paths.HTTPD_IPA_PKI_PROXY_CONF,
                 os.path.join(paths.USR_SHARE_IPA_DIR,
                              "ipa-pki-proxy.conf.template"),
-                add=True, force=secret_needs_sync)
+                add=True, force=True)
         else:
             if os.path.isfile(paths.HTTPD_IPA_PKI_PROXY_CONF):
                 os.remove(paths.HTTPD_IPA_PKI_PROXY_CONF)

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -20,6 +20,7 @@
 import pytest
 import re
 from ipaplatform.paths import paths
+from ipaplatform.osinfo import osinfo
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration.tasks import (
     clear_sssd_cache, get_host_ip_with_hostmask, remote_sssd_config,
@@ -1607,6 +1608,9 @@ class TestSudo_Functional(IntegrationTest):
         master.run_command([
             "ipa", "group-del", self.GROUP])
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora',
+        reason='freeipa ticket 10000')
     def test_007_sudorule_offline_caching_option_command(self):
         master = self.master
         kinit_admin(master)
@@ -1659,6 +1663,9 @@ class TestSudo_Functional(IntegrationTest):
         clear_sssd_cache(self.client)
         clear_sssd_cache(master)
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora',
+        reason='freeipa ticket 10000')
     def test_008_disable_sudorule_offline_caching(self):
         master = self.master
         kinit_admin(master)


### PR DESCRIPTION
The key sizes of ML-DSA 65 and 87 generate very large certificates,
CSRs, etc. These can be larger than the default mod_proxy AJP
setting allows (8192).

The equivalent value in PKI was updated to 65536 in dogtagpki
change. See:

https://github.com/dogtagpki/pki/commit/9d8d6d2
https://github.com/dogtagpki/pki/commit/3007eda
https://github.com/dogtagpki/pki/commit/8e667b2

Fixes: https://pagure.io/freeipa/issue/9988

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

## Summary by Sourcery

Tests:
- Adjust ACME integration CI job to run multiple ACME test classes with an increased timeout.