### PR TITLE
[Backport][ipa-4-13] constants: Use 24-byte key to check id TripleDES is supported

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -405,5 +405,5 @@ VAULT_WRAPPING_DEFAULT_ALGO = VAULT_WRAPPING_AES128_CBC
 
 # Add 3DES for backwards compatibility if supported
 if backend.cipher_supported(TripleDES(
-                            b"\x00" * 8), modes.CBC(b"\x00" * 8)):
+                            b"\x00" * 24), modes.CBC(b"\x00" * 8)):
     VAULT_WRAPPING_SUPPORTED_ALGOS += (VAULT_WRAPPING_3DES,)

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -152,7 +152,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-13-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-13/test_idm_api:

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
@@ -144,7 +144,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-13-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-13/test_kerberos_flags:

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
@@ -151,7 +151,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_commands.py
         template: *ci-ipa-4-13-latest
-        timeout: 5400
+        timeout: 6000
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-13/test_kerberos_flags:


### PR DESCRIPTION
This is a manual backport of PR #8391 to ipa-4-13.
Cherry-pick failed for the 2nd commit because the PRCI definitions differ on ipa-4-13 branch.

Auto-ack as the conflict resolution was trivial

## Summary by Sourcery

Adjust 3DES capability detection and update CI timeouts for command integration tests on the ipa-4-13 branch.

Enhancements:
- Change TripleDES support check to use a 24-byte key for determining availability of 3DES vault wrapping.

CI:
- Increase timeouts for ipa-4-13 command integration test jobs in gating and nightly CI definitions to reduce spurious failures.