### PR TITLE
Azure CI: Use Fedora 44

### DIFF
--- a/ipalib/util.py
+++ b/ipalib/util.py
@@ -292,6 +292,7 @@ def get_proper_tls_version_span(tls_version_min, tls_version_max):
 def create_https_connection(
     host, port=HTTPSConnection.default_port,
     cafile=None,
+    capath=None,
     client_certfile=None, client_keyfile=None,
     keyfile_passwd=None,
     tls_version_min=TLS_VERSION_DEFAULT_MIN,
@@ -327,13 +328,23 @@ def create_https_connection(
         "tls1.3": getattr(ssl, "OP_NO_TLSv1_3", 0),
     }
 
-    if cafile is None:
-        raise RuntimeError("cafile argument is required to perform server "
-                           "certificate verification")
+    if cafile is None and capath is None:
+        raise RuntimeError("cafile or capth argument is required to perform "
+                           "server certificate verification")
 
-    if not os.path.isfile(cafile) or not os.access(cafile, os.R_OK):
+    if (
+        cafile
+        and (not os.path.isfile(cafile) or not os.access(cafile, os.R_OK))
+    ):
         raise RuntimeError("cafile \'{file}\' doesn't exist or is unreadable".
                            format(file=cafile))
+
+    if (
+        capath
+        and (not os.path.isdir(capath) or not os.access(capath, os.R_OK))
+    ):
+        raise RuntimeError("capath \'{file}\' doesn't exist or is unreadable".
+                           format(file=capath))
 
     # official Python documentation states that the best option to get
     # TLSv1 and later is to setup SSLContext with PROTOCOL_SSLv23
@@ -370,7 +381,7 @@ def create_https_connection(
 
     ctx.verify_mode = ssl.CERT_REQUIRED
     ctx.check_hostname = True
-    ctx.load_verify_locations(cafile)
+    ctx.load_verify_locations(cafile, capath)
 
     if client_certfile is not None:
         if keyfile_passwd is not None:

--- a/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
+++ b/ipatests/azure/Dockerfiles/Dockerfile.build.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-toolbox:43
+FROM registry.fedoraproject.org/fedora-toolbox:44
 MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 

--- a/ipatests/azure/templates/variables-fedora.yml
+++ b/ipatests/azure/templates/variables-fedora.yml
@@ -1,7 +1,7 @@
 variables:
   IPA_PLATFORM: fedora
   # the Docker public image to build IPA packages (rpms)
-  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/fedora-toolbox:43'
+  DOCKER_BUILD_IMAGE: 'registry.fedoraproject.org/fedora-toolbox:44'
 
   # the Dockerfile to build Docker image for running IPA tests
   DOCKER_DOCKERFILE: ${{ format('Dockerfile.build.{0}', variables.IPA_PLATFORM) }}

--- a/ipatests/test_ipalib/test_util.py
+++ b/ipatests/test_ipalib/test_util.py
@@ -68,9 +68,11 @@ def test_tls_version_span(minver, maxver, opt, expected):
     assert get_proper_tls_version_span(minver, maxver) == expected
     # file must exist and contain certs
     cafile = ssl.get_default_verify_paths().cafile
+    capath = ssl.get_default_verify_paths().capath
     conn = create_https_connection(
         "invalid.test",
         cafile=cafile,
+        capath=capath,
         tls_version_min=minver,
         tls_version_max=maxver
     )

--- a/ipatests/test_ipaserver/test_install/test_installutils.py
+++ b/ipatests/test_ipaserver/test_install/test_installutils.py
@@ -286,7 +286,12 @@ def test_cgroup_v2_insufficient_ram_with_ca(mock_exists, mock_in_container):
 def test_cgroup_v2_no_limit_ok(mock_psutil, mock_exists, mock_in_container):
     """In a container and just miss the minimum RAM required"""
     mock_in_container.return_value = True
-    fake_memory = psutil._pslinux.svmem
+    # pylint: disable=E1101
+    try:
+        fake_memory = psutil._pslinux.svmem
+    except AttributeError:
+        fake_memory = psutil._pslinux.ntp.svmem
+    # pylint: enable=E1101
     fake_memory.available = int(RAM_OK)
     mock_psutil.return_value = fake_memory
     mock_exists.side_effect = [False, True, True]
@@ -301,7 +306,12 @@ def test_cgroup_v2_no_limit_ok(mock_psutil, mock_exists, mock_in_container):
 def test_cgroup_v2_no_limit_not_ok(mock_psutil, mock_exists, mock_in_container):
     """In a container and just miss the minimum RAM required"""
     mock_in_container.return_value = True
-    fake_memory = psutil._pslinux.svmem
+    # pylint: disable=E1101
+    try:
+        fake_memory = psutil._pslinux.svmem
+    except AttributeError:
+        fake_memory = psutil._pslinux.ntp.svmem
+    # pylint: enable=E1101
     fake_memory.available = int(RAM_NOT_OK)
     mock_psutil.return_value = fake_memory
     mock_exists.side_effect = [False, True, True]
@@ -315,7 +325,12 @@ def test_cgroup_v2_no_limit_not_ok(mock_psutil, mock_exists, mock_in_container):
 def test_bare_insufficient_ram_with_ca(mock_psutil, mock_in_container):
     """Not a container and insufficient RAM"""
     mock_in_container.return_value = False
-    fake_memory = psutil._pslinux.svmem
+    # pylint: disable=E1101
+    try:
+        fake_memory = psutil._pslinux.svmem
+    except AttributeError:
+        fake_memory = psutil._pslinux.ntp.svmem
+    # pylint: enable=E1101
     fake_memory.available = int(RAM_NOT_OK)
     mock_psutil.return_value = fake_memory
 
@@ -328,7 +343,12 @@ def test_bare_insufficient_ram_with_ca(mock_psutil, mock_in_container):
 def test_bare_ram_ok(mock_psutil, mock_in_container):
     """Not a container and sufficient RAM"""
     mock_in_container.return_value = False
-    fake_memory = psutil._pslinux.svmem
+    # pylint: disable=E1101
+    try:
+        fake_memory = psutil._pslinux.svmem
+    except AttributeError:
+        fake_memory = psutil._pslinux.ntp.svmem
+    # pylint: enable=E1101
     fake_memory.available = int(RAM_OK)
     mock_psutil.return_value = fake_memory
 


### PR DESCRIPTION
Fedora 44 is now officially available, switch azure CI to this version.

Related: https://pagure.io/freeipa/issue/9992

## Summary by Sourcery

Build:
- Switch Fedora Azure CI Docker build image from fedora-toolbox:43 to fedora-toolbox:44.