### PR TITLE
PRCI: switch testing from f42 and f43 to f43 and f44

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -42,8 +42,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -150,10 +150,24 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-master-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  fedora-latest/test_commands_2:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-latest/test_idm_api:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -140,7 +140,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_sudo.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest/test_commands:

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-latest/build_url}'
         test_suite: test_integration/test_sudo.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest/test_commands:

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -62,8 +62,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -146,10 +146,24 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-master-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  fedora-latest/test_commands_2:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-latest/test_kerberos_flags:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -39,8 +39,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -67,10 +67,26 @@ jobs:
         build_url: '{389ds-fedora/build_url}'
         update_packages: True
         copr: '@389ds/389-ds-base-nightly'
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-master-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  389ds-fedora/test_commands_2:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-nightly'
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
 
   389ds-fedora/test_server_del:
     requires: [389ds-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -43,8 +43,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -142,7 +142,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_sudo.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest/test_commands:

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -62,8 +62,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -153,10 +153,25 @@ jobs:
       args:
         build_url: '{fedora-latest/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-master-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  fedora-latest/test_commands_2:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        selinux_enforcing: True
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-latest/test_kerberos_flags:
     requires: [fedora-latest/build]

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -266,7 +266,7 @@ jobs:
         copr: '@sssd/nightly'
         test_suite: test_integration/test_sudo.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   sssd-fedora/test_trust:

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -51,8 +51,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -65,10 +65,26 @@ jobs:
         build_url: '{sssd-fedora/build_url}'
         update_packages: True
         copr: '@sssd/nightly'
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-master-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  sssd-fedora/test_commands_2:
+    requires: [sssd-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{sssd-fedora/build_url}'
+        update_packages: True
+        copr: '@sssd/nightly'
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
 
   sssd-fedora/test_external_idp:
     requires: [sssd-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -161,10 +161,26 @@ jobs:
         build_url: '{testing-fedora/build_url}'
         update_packages: True
         enable_testing_repo: True
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-master-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  testing-fedora/test_commands_2:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        enable_testing_repo: True
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
 
   testing-fedora/test_kerberos_flags:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -63,8 +63,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -149,7 +149,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_sudo.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   testing-fedora/test_commands:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -63,8 +63,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -155,7 +155,7 @@ jobs:
         enable_testing_repo: True
         test_suite: test_integration/test_sudo.py
         template: *ci-master-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   testing-fedora/test_commands:

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -168,10 +168,27 @@ jobs:
         update_packages: True
         selinux_enforcing: True
         enable_testing_repo: True
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-master-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  testing-fedora/test_commands_2:
+    requires: [testing-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{testing-fedora/build_url}'
+        update_packages: True
+        selinux_enforcing: True
+        enable_testing_repo: True
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
 
   testing-fedora/test_kerberos_flags:
     requires: [testing-fedora/build]

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -62,8 +62,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
-          name: freeipa/ci-master-f42
-          version: 0.0.9
+          name: freeipa/ci-master-f43
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -136,7 +136,7 @@ jobs:
         build_url: '{fedora-previous/build_url}'
         test_suite: test_integration/test_sudo.py
         template: *ci-master-previous
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-previous/test_commands:

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -146,10 +146,24 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-previous/build_url}'
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-master-previous
         timeout: 6000
         topology: *master_1repl_1client
+
+  fedora-previous/test_commands_2:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-previous
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-previous/test_kerberos_flags:
     requires: [fedora-previous/build]

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -157,6 +157,21 @@ jobs:
         timeout: 6000
         topology: *master_1repl_1client
 
+  fedora-rawhide/test_commands_2:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl
+
   fedora-rawhide/test_kerberos_flags:
     requires: [fedora-rawhide/build]
     priority: 50

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -141,7 +141,7 @@ jobs:
         update_packages: True
         test_suite: test_integration/test_sudo.py
         template: *ci-master-frawhide
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-rawhide/test_commands:

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -64,8 +64,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -3235,6 +3235,11 @@ def get_healthcheck_version(host):
     return get_package_version(host, '*ipa-healthcheck')
 
 
+def get_softhsm_version(host):
+    """Get softhsm version on remote host"""
+    return get_package_version(host, 'softhsm')
+
+
 def wait_for_ipa_to_start(host, timeout=60):
     """Wait up to timeout seconds for ipa to start on a given host.
 

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -19,6 +19,7 @@ import yaml
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
+from ipatests.util import xfail_context
 from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.paths import paths
 from ipapython.dnsutil import DNSResolver
@@ -346,9 +347,13 @@ class TestInstallDNSSECFirst(IntegrationTest):
         ]
         self.master.run_command(args)
         # test master
-        assert wait_until_record_is_signed(
-            self.master.ip, root_zone, timeout=100
-        ), "Zone %s is not signed (master)" % root_zone
+        softhsm_version = tasks.parse_version(
+            tasks.get_softhsm_version(self.master))
+        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+                           'https://pagure.io/freeipa/issue/9920'):
+            assert wait_until_record_is_signed(
+                self.master.ip, root_zone, timeout=100
+            ), "Zone %s is not signed (master)" % root_zone
 
         # test replica
         assert wait_until_record_is_signed(
@@ -369,9 +374,13 @@ class TestInstallDNSSECFirst(IntegrationTest):
         tasks.restart_named(self.master, self.replicas[0])
 
         # wait until zone is signed
-        assert wait_until_record_is_signed(
-            self.master.ip, example_test_zone, timeout=100
-        ), "Zone %s is not signed (master)" % example_test_zone
+        softhsm_version = tasks.parse_version(
+            tasks.get_softhsm_version(self.master))
+        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+                           'https://pagure.io/freeipa/issue/9920'):
+            assert wait_until_record_is_signed(
+                self.master.ip, example_test_zone, timeout=100
+            ), "Zone %s is not signed (master)" % example_test_zone
         # wait until zone is signed
         assert wait_until_record_is_signed(
             self.replicas[0].ip, example_test_zone, timeout=200
@@ -425,8 +434,12 @@ class TestInstallDNSSECFirst(IntegrationTest):
         Validate signed DNS records, using our own signed root zone
         """
         # extract DSKEY from root zone
-        ans = resolve_with_dnssec(self.master.ip, root_zone,
-                                  rtype="DNSKEY")
+        softhsm_version = tasks.parse_version(
+            tasks.get_softhsm_version(self.master))
+        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+                           'https://pagure.io/freeipa/issue/9920'):
+            ans = resolve_with_dnssec(self.master.ip, root_zone,
+                                      rtype="DNSKEY")
         dnskey_rrset = ans.response.get_rrset(ans.response.answer,
                                               dns.name.from_text(root_zone),
                                               dns.rdataclass.IN,
@@ -486,9 +499,13 @@ class TestInstallDNSSECFirst(IntegrationTest):
             )
 
         # extract DSKEY from root zone
-        ans = resolve_with_dnssec(
-            self.master.ip, root_zone, rtype="DNSKEY"
-        )
+        softhsm_version = tasks.parse_version(
+            tasks.get_softhsm_version(self.master))
+        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+                           'https://pagure.io/freeipa/issue/9920'):
+            ans = resolve_with_dnssec(
+                self.master.ip, root_zone, rtype="DNSKEY"
+            )
         dnskey_rrset = ans.response.get_rrset(
             ans.response.answer,
             dns.name.from_text(root_zone),


### PR DESCRIPTION
Fedora 44 is already available and Fedora 42 will be EOL Wed 2026-05-13 according to Fedora schedule:
https://fedorapeople.org/groups/schedule/f-42/f-42-all-tasks.html

Start testing on fedora 43 and fedora 44.

Related: https://pagure.io/freeipa/issue/9992

## Summary by Sourcery

Update CI test templates to use newer Fedora-based images for gating and nightly jobs.

CI:
- Switch CI 'latest' jobs from Fedora 43 to Fedora 44 images across gating and nightly pipelines.
- Update 'previous' nightly jobs from Fedora 42 to Fedora 43 images.
- Align CI container image version tags with the new Fedora image selections.