### PR TITLE
[ipa-4-13] CI: switch testing from fedora 43 to fedora 44

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -42,7 +42,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-13-latest
-          name: freeipa/ci-ipa-4-13-f43
+          name: freeipa/ci-ipa-4-13-f44
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -150,10 +150,24 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-ipa-4-13-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-13/test_commands_2:
+    requires: [fedora-latest-ipa-4-13/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-13/build_url}'
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-ipa-4-13-latest
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-latest-ipa-4-13/test_idm_api:
     requires: [fedora-latest-ipa-4-13/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
@@ -142,10 +142,24 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-ipa-4-13-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-13/test_commands_2:
+    requires: [fedora-latest-ipa-4-13/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-13/build_url}'
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-ipa-4-13-latest
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-latest-ipa-4-13/test_kerberos_flags:
     requires: [fedora-latest-ipa-4-13/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
@@ -58,7 +58,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-13-latest
-          name: freeipa/ci-ipa-4-13-f43
+          name: freeipa/ci-ipa-4-13-f44
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
@@ -149,10 +149,25 @@ jobs:
       args:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
         selinux_enforcing: True
-        test_suite: test_integration/test_commands.py
+        test_suite: test_integration/test_commands.py::TestIPACommand
         template: *ci-ipa-4-13-latest
         timeout: 6000
         topology: *master_1repl_1client
+
+  fedora-latest-ipa-4-13/test_commands_2:
+    requires: [fedora-latest-ipa-4-13/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest-ipa-4-13/build_url}'
+        selinux_enforcing: True
+        test_suite: >-
+            test_integration/test_commands.py::TestIPACommandWithoutReplica
+            test_integration/test_commands.py::TestIPAautomount
+        template: *ci-ipa-4-13-latest
+        timeout: 3600
+        topology: *master_1repl
 
   fedora-latest-ipa-4-13/test_kerberos_flags:
     requires: [fedora-latest-ipa-4-13/build]

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
@@ -58,7 +58,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-13-latest
-          name: freeipa/ci-ipa-4-13-f43
+          name: freeipa/ci-ipa-4-13-f44
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -64,7 +64,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-13-latest
-          name: freeipa/ci-ipa-4-13-f43
+          name: freeipa/ci-ipa-4-13-f44
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -3139,6 +3139,11 @@ def get_healthcheck_version(host):
     return get_package_version(host, '*ipa-healthcheck')
 
 
+def get_softhsm_version(host):
+    """Get softhsm version on remote host"""
+    return get_package_version(host, 'softhsm')
+
+
 def wait_for_ipa_to_start(host, timeout=60):
     """Wait up to timeout seconds for ipa to start on a given host.
 

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -19,6 +19,7 @@ import yaml
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.pytest_ipa.integration.firewall import Firewall
+from ipatests.util import xfail_context
 from ipaplatform.tasks import tasks as platform_tasks
 from ipaplatform.paths import paths
 from ipapython.dnsutil import DNSResolver
@@ -346,9 +347,13 @@ class TestInstallDNSSECFirst(IntegrationTest):
         ]
         self.master.run_command(args)
         # test master
-        assert wait_until_record_is_signed(
-            self.master.ip, root_zone, timeout=100
-        ), "Zone %s is not signed (master)" % root_zone
+        softhsm_version = tasks.parse_version(
+            tasks.get_softhsm_version(self.master))
+        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+                           'https://pagure.io/freeipa/issue/9920'):
+            assert wait_until_record_is_signed(
+                self.master.ip, root_zone, timeout=100
+            ), "Zone %s is not signed (master)" % root_zone
 
         # test replica
         assert wait_until_record_is_signed(
@@ -369,9 +374,13 @@ class TestInstallDNSSECFirst(IntegrationTest):
         tasks.restart_named(self.master, self.replicas[0])
 
         # wait until zone is signed
-        assert wait_until_record_is_signed(
-            self.master.ip, example_test_zone, timeout=100
-        ), "Zone %s is not signed (master)" % example_test_zone
+        softhsm_version = tasks.parse_version(
+            tasks.get_softhsm_version(self.master))
+        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+                           'https://pagure.io/freeipa/issue/9920'):
+            assert wait_until_record_is_signed(
+                self.master.ip, example_test_zone, timeout=100
+            ), "Zone %s is not signed (master)" % example_test_zone
         # wait until zone is signed
         assert wait_until_record_is_signed(
             self.replicas[0].ip, example_test_zone, timeout=200
@@ -425,8 +434,12 @@ class TestInstallDNSSECFirst(IntegrationTest):
         Validate signed DNS records, using our own signed root zone
         """
         # extract DSKEY from root zone
-        ans = resolve_with_dnssec(self.master.ip, root_zone,
-                                  rtype="DNSKEY")
+        softhsm_version = tasks.parse_version(
+            tasks.get_softhsm_version(self.master))
+        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+                           'https://pagure.io/freeipa/issue/9920'):
+            ans = resolve_with_dnssec(self.master.ip, root_zone,
+                                      rtype="DNSKEY")
         dnskey_rrset = ans.response.get_rrset(ans.response.answer,
                                               dns.name.from_text(root_zone),
                                               dns.rdataclass.IN,
@@ -486,9 +499,13 @@ class TestInstallDNSSECFirst(IntegrationTest):
             )
 
         # extract DSKEY from root zone
-        ans = resolve_with_dnssec(
-            self.master.ip, root_zone, rtype="DNSKEY"
-        )
+        softhsm_version = tasks.parse_version(
+            tasks.get_softhsm_version(self.master))
+        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+                           'https://pagure.io/freeipa/issue/9920'):
+            ans = resolve_with_dnssec(
+                self.master.ip, root_zone, rtype="DNSKEY"
+            )
         dnskey_rrset = ans.response.get_rrset(
             ans.response.answer,
             dns.name.from_text(root_zone),


### PR DESCRIPTION
Fedora 44 is already available and Fedora 42 will be EOL Wed 2026-05-13 according to Fedora schedule:
https://fedorapeople.org/groups/schedule/f-42/f-42-all-tasks.html

Start testing on fedora 44.

Fixes: https://pagure.io/freeipa/issue/9992

## Summary by Sourcery

CI:
- Switch ipa-4-13 gating, nightly, SELinux nightly, and temp_commit CI templates from the Fedora 43 image to the Fedora 44 image.