### PR TITLE
[Backport][ipa-4-9] Enforce Same-Site cookie

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 35 - DO NOT REMOVE THIS LINE
+# VERSION 36 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -68,7 +68,7 @@ ServerTokens Prod
   AuthName "Kerberos Login"
   GssapiUseSessions On
   Session On
-  SessionCookieName ipa_session path=/ipa;httponly;secure;
+  SessionCookieName ipa_session path=/ipa;httponly;secure;SameSite=strict;
   SessionHeader IPASESSION
   # Uncomment the following to have shorter sessions, but beware this may break
   # old IPA client tols that incorrectly parse cookies.
@@ -130,7 +130,7 @@ Alias /ipa/session/cookie "/usr/share/ipa/gssapi.login"
 
   GssapiUseSessions On
   Session On
-  SessionCookieName ipa_session path=/ipa;httponly;secure;
+  SessionCookieName ipa_session path=/ipa;httponly;secure;SameSite=strict;
   SessionHeader IPASESSION
   SessionMaxAge 1800
   GssapiSessionKey file:$GSSAPI_SESSION_KEY


### PR DESCRIPTION
This PR was opened automatically because PR #8394 was pushed to ipa-4-12 and backport to ipa-4-9 is required.

## Summary by Sourcery

Enhancements:
- Align ipa.conf Apache template cookie settings with newer branches to consistently enforce SameSite behavior across releases.