### PR TITLE
temp_cmmit

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -53,9 +53,8 @@ topologies:
     name: ipa_ipa_trust
     cpu: 7
     memory: 14750
-
 jobs:
-  fedora-latest/build:
+  fedora-rawhide/build:
     requires: []
     priority: 100
     job:
@@ -63,20 +62,32 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+        template: &ci-master-frawhide
+          name: freeipa/ci-master-frawhide
+          version: 0.10.1
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
-    requires: [fedora-latest/build]
+  fedora-rawhide/temp_commit1:
+    requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-latest
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallPQCCACerts
+        template: *ci-master-frawhide
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit2:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallPQCIPACerts
+        template: *ci-master-frawhide
+        timeout: 3600
+        topology: *master_1repl


### PR DESCRIPTION
## Summary by Sourcery

Update temporary CI configuration to run targeted installation tests on Fedora Rawhide using the new ci-master-frawhide template.

New Features:
- Add two dedicated Fedora Rawhide pytest jobs to run specific installation test classes for PQC CA and IPA certs.

Enhancements:
- Switch temporary CI jobs from the Fedora latest template to the Fedora Rawhide ci-master-frawhide template and align topologies accordingly.

CI:
- Adjust PR CI configuration references to use the updated temporary CI definition.