### PR TITLE
[Backport][ipa-4-13] replica conncheck: use crypto-policies in temp krb5.conf

### DIFF
--- a/install/tools/ipa-replica-conncheck.in
+++ b/install/tools/ipa-replica-conncheck.in
@@ -237,7 +237,11 @@ def configure_krb5_conf(realm, kdc, filename):
     krbconf.setSubSectionDelimiters(("{","}"))
     krbconf.setIndent(("","  ","    "))
 
-    opts = [{'name':'comment', 'type':'comment', 'value':'File created by ipa-replica-conncheck'},
+    opts = [{'name':'comment', 'type':'comment',
+             'value':'File created by ipa-replica-conncheck'},
+            {'name':'empty', 'type':'empty'},
+            {'name':'include', 'type':'option', 'delim':' ',
+             'value':'/etc/krb5.conf.d/crypto-policies'},
             {'name':'empty', 'type':'empty'}]
 
     #[libdefaults]


### PR DESCRIPTION
This PR was opened automatically because PR #8398 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Backport changes to ipa-replica-conncheck to align replica connectivity checks with the behavior introduced on the master branch, ensuring consistency for ipa-4-13.