### PR TITLE
Spec file: move named-related files to server-dns package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1781,8 +1781,6 @@ fi
 %ghost %attr(0640,root,root) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa-pki-proxy.conf
 %ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/ipa/kdcproxy/ipa-kdc-proxy.conf
 %ghost %attr(0644,root,root) %config(noreplace) %{_usr}/share/ipa/html/ca.crt
-%ghost %attr(0640,root,named) %config(noreplace) %{_sysconfdir}/named/ipa-ext.conf
-%ghost %attr(0640,root,named) %config(noreplace) %{_sysconfdir}/named/ipa-options-ext.conf
 %dir %{_usr}/share/ipa/updates/
 %{_usr}/share/ipa/updates/*
 %dir %{_localstatedir}/lib/ipa
@@ -1795,7 +1793,6 @@ fi
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/private
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/passwds
 %ghost %attr(775,root,pkiuser) %{_localstatedir}/lib/ipa/pki-ca/publish
-%ghost %attr(770,named,named) %{_localstatedir}/named/dyndb-ldap/ipa
 %dir %attr(0700,root,root) %{_sysconfdir}/ipa/custodia
 %dir %{_usr}/share/ipa/schema.d
 %attr(0644,root,root) %{_usr}/share/ipa/schema.d/README
@@ -1817,6 +1814,9 @@ fi
 %attr(644,root,root) %{_unitdir}/ipa-dnskeysyncd.service
 %attr(644,root,root) %{_unitdir}/ipa-ods-exporter.socket
 %attr(644,root,root) %{_unitdir}/ipa-ods-exporter.service
+%ghost %attr(0640,root,named) %config(noreplace) %{_sysconfdir}/named/ipa-ext.conf
+%ghost %attr(0640,root,named) %config(noreplace) %{_sysconfdir}/named/ipa-options-ext.conf
+%ghost %attr(770,named,named) %{_localstatedir}/named/dyndb-ldap/ipa
 
 %files server-encrypted-dns
 %doc README.md Contributors.txt


### PR DESCRIPTION
The files /etc/named/ipa-ext.conf /etc/named/ipa-options-ext.conf
and the directory /var/named/dyndb-ldap/ipa are installed only
when IPA has the server-dns package.
Their attributes were set in the server-common package definition,
and they should be owned by named user/group which only exists
when the bind package is installed.

This results in removal of server-common when the bind package is
removed.

By moving their attributes definition in the server-dns package,
it is possible to remove the bind package but keep ipa-server-common.

Fixes: https://pagure.io/freeipa/issue/9786

## Summary by Sourcery

Adjust CI configuration to run a Fedora Rawhide build and targeted installation test focusing on scenarios without the named service.

CI:
- Switch PR CI temporary job from Fedora latest to Fedora Rawhide using the updated ci-master-frawhide template.

Tests:
- Add a Rawhide installation test job that runs the TestInstallWithoutNamed scenario with updated topology and timeout settings.