### PR TITLE
ipatests: fix replica forward-zone test teardown resolv.conf restore

### DIFF
--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -941,10 +941,10 @@ class TestReplicaInForwardZone(IntegrationTest):
                          r_new_hostname)
 
         try:
-            # install client with a hostname in the forward zone
-            tasks.install_client(self.master, replica,
-                                 extra_args=['--hostname', r_new_hostname])
-
+            tasks.install_client(
+                self.master, replica,
+                extra_args=['--hostname', r_new_hostname],
+            )
             # Configure firewall first
             Firewall(replica).enable_services(["freeipa-ldap",
                                                "freeipa-ldaps"])
@@ -959,6 +959,10 @@ class TestReplicaInForwardZone(IntegrationTest):
             # Restore /etc/hosts on master and replica
             restore_etc_hosts(master)
             restore_etc_hosts(replica)
+            if replica.resolver.has_backups():
+                # NM may rewrite resolv.conf during replica install (RHEL)
+                replica.resolver.current_state = replica.resolver._get_state()
+                replica.resolver.restore()
 
 
 class TestHiddenReplicaPromotion(IntegrationTest):


### PR DESCRIPTION
Backup and restore /etc/resolv.conf in test_replica_install_in_forward_zone so ipa-replica-install and NetworkManager changes do not break uninstall_master resolver checks. Use nameservers=None in install_client to avoid stacking resolver backups.

Fixes: https://pagure.io/freeipa/issue/9995

## Summary by Sourcery

Ensure forward-zone replica promotion tests properly preserve and restore DNS resolver configuration to keep teardown resolver checks reliable.

Tests:
- Add helper utilities to back up and restore /etc/resolv.conf in integration tests.
- Update the forward-zone replica install test to bypass client resolver helpers and explicitly restore resolv.conf during teardown to avoid stacked backups.