### PR TITLE
Remove exit 1

### DIFF
--- a/ipatests/azure/templates/test-jobs.yml
+++ b/ipatests/azure/templates/test-jobs.yml
@@ -200,8 +200,6 @@ steps:
         "$CONTAINER_COREDUMP" \
         /bin/bash --noprofile --norc -eux \
             "${IPA_TESTS_REPO_PATH}/${IPA_TESTS_SCRIPTS}/dump_cores.sh"
-    # there should be no crashes
-    exit 1
   condition: succeededOrFailed()
   displayName: Check for coredumps
 


### PR DESCRIPTION
There seems to be a leftover exit 1 in the pipeline which forces the pipeline to fail at least once always! Removing the exit 1 will allow remove the first mandatory re-run for Azure.

## Summary by Sourcery

CI:
- Stop forcing the Azure test job to fail by removing an unconditional exit 1 in the coredump check step.