### PR TITLE
[Backport][ipa-4-13] Spec file: move named-related files to server-dns package

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1784,8 +1784,6 @@ fi
 %ghost %attr(0640,root,root) %config(noreplace) %{_sysconfdir}/httpd/conf.d/ipa-pki-proxy.conf
 %ghost %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/ipa/kdcproxy/ipa-kdc-proxy.conf
 %ghost %attr(0644,root,root) %config(noreplace) %{_usr}/share/ipa/html/ca.crt
-%ghost %attr(0640,root,named) %config(noreplace) %{_sysconfdir}/named/ipa-ext.conf
-%ghost %attr(0640,root,named) %config(noreplace) %{_sysconfdir}/named/ipa-options-ext.conf
 %dir %{_usr}/share/ipa/updates/
 %{_usr}/share/ipa/updates/*
 %dir %{_localstatedir}/lib/ipa
@@ -1798,7 +1796,6 @@ fi
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/private
 %attr(700,root,root) %dir %{_localstatedir}/lib/ipa/passwds
 %ghost %attr(775,root,pkiuser) %{_localstatedir}/lib/ipa/pki-ca/publish
-%ghost %attr(770,named,named) %{_localstatedir}/named/dyndb-ldap/ipa
 %dir %attr(0700,root,root) %{_sysconfdir}/ipa/custodia
 %dir %{_usr}/share/ipa/schema.d
 %attr(0644,root,root) %{_usr}/share/ipa/schema.d/README
@@ -1820,6 +1817,9 @@ fi
 %attr(644,root,root) %{_unitdir}/ipa-dnskeysyncd.service
 %attr(644,root,root) %{_unitdir}/ipa-ods-exporter.socket
 %attr(644,root,root) %{_unitdir}/ipa-ods-exporter.service
+%ghost %attr(0640,root,named) %config(noreplace) %{_sysconfdir}/named/ipa-ext.conf
+%ghost %attr(0640,root,named) %config(noreplace) %{_sysconfdir}/named/ipa-options-ext.conf
+%ghost %attr(770,named,named) %{_localstatedir}/named/dyndb-ldap/ipa
 
 %files server-encrypted-dns
 %doc README.md Contributors.txt


### PR DESCRIPTION
This PR was opened automatically because PR #8414 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Build:
- Update FreeIPA RPM spec to move named-related files from the main package into the server-dns subpackage.