### PR TITLE
ipatests: remove client host from LDAP after uninstall in authselect tests.

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -76,7 +76,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_authselect.py
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_authselect.py
+++ b/ipatests/test_integration/test_authselect.py
@@ -84,10 +84,18 @@ class TestClientInstallation(IntegrationTest):
         cmd.extend(extraargs)
         return self.client.run_command(cmd, raiseonerr=False)
 
+    def _remove_client_host_from_master(self):
+        tasks.kinit_admin(self.master)
+        tasks.host_del(
+            self.master, self.client.hostname, '--updatedns',
+            raiseonerr=False)
+
     def _uninstall_client(self):
-        return self.client.run_command(
+        result = self.client.run_command(
             ['ipa-client-install', '--uninstall', '-U'],
             raiseonerr=False)
+        self._remove_client_host_from_master()
+        return result
 
     def test_install_client_no_preconfigured_profile(self):
         """


### PR DESCRIPTION
Repeated install/uninstall cycles in TestClientInstallation left the client host entry on the master. ipa-client-install --uninstall cleans up the client locally but does not delete the host from IPA, so the next enroll failed with "Host is already joined" (e.g. test_install_client_no_sudo).

Delete the host with ipa host-del on the master after each uninstall so later client installations in the same test class can succeed.

Fixes: https://pagure.io/freeipa/issue/9996

## Summary by Sourcery

Ensure authselect integration tests fully clean up IPA client hosts between install/uninstall cycles to allow repeated enrollments in the same test class.

Bug Fixes:
- Prevent repeated client installation tests from failing with "Host is already joined" by deleting the client host entry on the master after each uninstall.

Tests:
- Add test-side cleanup that removes the IPA client host from the master after client uninstall in authselect integration tests.