### PR TITLE
Refactor algorithm config and the override file

### DIFF
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -587,6 +587,16 @@ class CAInstance(DogtagInstance):
         cfg = dict(
             pki_ds_secure_connection=self.use_ldaps
         )
+        # Force the IPA-specific options to None. They should be
+        # overridden later.
+        cfg['ipa_key_algorithm'] = None
+        cfg['ipa_key_size'] = None
+        cfg['ipa_key_type'] = None
+        cfg['ipa_signing_algorithm'] = None
+        if self.pki_config_override:
+            pre_config = self._create_spawn_config(cfg)
+        else:
+            pre_config = {'CA': {}}
 
         if self.tokenname:
             module_name = os.path.basename(
@@ -599,36 +609,62 @@ class CAInstance(DogtagInstance):
             cfg['pki_token_password'] = self.token_password
             cfg['pki_sslserver_token'] = 'internal'
 
+        pki_key_size = pre_config[self.subsystem].get(
+            "pki_ca_signing_key_size"
+        )
+        pki_key_alg = pre_config[self.subsystem].get(
+            "pki_ca_signing_key_algorithm"
+        )
+        pki_sign_alg = pre_config[self.subsystem].get(
+            "pki_ca_signing_signing_algorithm"
+        )
         ipa_ca_key_size = None
         if self.ca_key_type:
             (self.ca_key_type, ipa_ca_key_size) = (
                 certs.get_key_type_and_strength(self.ca_key_type, True)
             )
+        if pki_key_size:
+            ipa_ca_key_size = pki_key_size
 
         if self.ca_key_type == "rsa":
-            if self.ca_signing_algorithm is not None:
-                ipa_ca_key_algorithm = self.ca_signing_algorithm
+            if pki_key_alg:
+                ipa_ca_key_algorithm = pki_key_alg
             else:
+                # the default
                 ipa_ca_key_algorithm = "SHA256withRSA"
+            if self.ca_signing_algorithm is not None:
+                ipa_key_algorithm = self.ca_signing_algorithm
+            elif pki_sign_alg:
+                ipa_key_algorithm = pki_sign_alg
+            else:
+                # the default
+                ipa_key_algorithm = "SHA256withRSA"
             if ipa_ca_key_size is None:
                 # the default
                 ipa_ca_key_size = "3072"
-            ipa_key_algorithm = "SHA256withRSA"
             ipa_key_size = "2048"
-            ipa_signing_algorithm = "SHA256withRSA"
+            ipa_signing_algorithm = ipa_key_algorithm
         elif self.ca_key_type == "mldsa":
+            # overriding ML-DSA via override is complex
             if ipa_ca_key_size is None:
                 # the default
                 ipa_ca_key_size = "65"
                 # ipa_ca_key_size = "87"  # FIXME
             ipa_key_size = "65"
-            ipa_ca_key_algorithm = f"ML-DSA-{ipa_ca_key_size}"
+            if pki_key_alg:
+                ipa_ca_key_algorithm = pki_key_alg
+            else:
+                ipa_ca_key_algorithm = f"ML-DSA-{ipa_ca_key_size}"
             if self.ca_signing_algorithm is not None:
-                cfg['ipa_ca_signing_algorithm'] = self.ca_signing_algorithm
+                ipa_key_algorithm = self.ca_signing_algorithm
+            elif pki_sign_alg:
+                ipa_key_algorithm = pki_sign_alg
+            else:
+                ipa_key_algorithm = ipa_ca_key_algorithm
+            if pki_sign_alg:
+                ipa_signing_algorithm = pki_sign_alg
             else:
                 ipa_signing_algorithm = ipa_ca_key_algorithm
-            ipa_key_algorithm = ipa_ca_key_algorithm
-            ipa_signing_algorithm = ipa_ca_key_algorithm
         else:
             # Replica install. Determine the CA settings from the CA
             # certificate.
@@ -642,12 +678,16 @@ class CAInstance(DogtagInstance):
         # FIXME: add some validation that the options are compatible.
         #        e.g. that an ML-DSA key doesn't have an RSA signing method.
         cfg['ipa_ca_key_size'] = ipa_ca_key_size
-        cfg['ipa_ca_key_algorithm'] = ipa_ca_key_algorithm
-
         cfg['ipa_key_size'] = ipa_key_size
-        cfg['ipa_key_algorithm'] = ipa_key_algorithm
         cfg['ipa_key_type'] = self.ca_key_type
+        # signature on the CA certificate
+        cfg['pki_ca_signing_key_algorithm'] = ipa_ca_key_algorithm
+        # signature on the certificates the CA issues
+        cfg['ipa_key_algorithm'] = ipa_key_algorithm
+        # signature the CA uses to sign keys
         cfg['ipa_signing_algorithm'] = ipa_signing_algorithm
+        # tomcat Server-Cert
+        cfg['pki_ssl_server_key_algorithm'] = ipa_signing_algorithm
 
         cfg['pki_random_serial_numbers_enable'] = self.random_serial_numbers
         if self.random_serial_numbers:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -772,12 +772,6 @@ def install_check(installer):
         options.ntp_servers, options.ntp_pool = timeconf.get_time_source()
 
     (keytype, keysize) = get_key_type_and_strength(api.env.key_type_size)
-    if options.ca_key_type:
-        (ca_key_type, ca_key_size) = (
-            get_key_type_and_strength(options.ca_key_type, True)
-        )
-    else:
-        (ca_key_type, ca_key_size) = ("rsa", "2048")
 
     print()
     print("The IPA Master Server will be configured with:")
@@ -785,7 +779,6 @@ def install_check(installer):
     print("IP address(es):   %s" % ", ".join(str(ip) for ip in ip_addresses))
     print("Domain name:      %s" % domain_name)
     print("Realm name:       %s" % realm_name)
-    print("CA Key type/size: %s:%s" % (ca_key_type.upper(), ca_key_size))
     print("Key type/size:    %s:%s" % (keytype.upper(), keysize))
     print()
 


### PR DESCRIPTION
What I had implemented originally was honestly a hot mess and I
hadn't considered the impact of an override file. I tried to
clean things up, or at least make it more readable, so that
choices are applied in this order:

 - cli options
 - override file
 - defaults

One exception is the CA key size. Because the cli option can pass
in type:size I'm cheating a bit. The method that parses this out
is unaware of overrides so it will return either what is requested
or the default. So passing in --ca-key-type=rsa will result in
rsa:3072. I allow the pki override to override whatever the key
value is in this case. If you're saavy enough to use an override
then I'll assume you know what you're doing, even if you're passing
in conflicting values.

Fixes: https://pagure.io/freeipa/issue/9991
Fixes: https://pagure.io/freeipa/issue/9993

Signed-off-by: Rob Crittenden <rcritten@redhat.com>

## Summary by Sourcery

Refine CA key and signing algorithm configuration to consistently apply CLI options, override files, and defaults while improving PKI algorithm mapping and outputs.

Bug Fixes:
- Ensure CA key size, CA signing algorithm, and general signing algorithms correctly respect PKI override configuration and CLI options in precedence order.
- Fix handling of ML-DSA CA and signing algorithms so overrides and defaults interact coherently instead of producing inconsistent key configuration.
- Remove outdated CA key type/size reporting from server installation checks that no longer matches the actual configuration path.

CI:
- Point the PR CI configuration to the standard gating definition file for consistent pipeline behavior.

Tests:
- Adjust CI temporary test configuration to run targeted PKI override and SHA384-with-RSA installation tests for the updated algorithm configuration behavior.