### PR TITLE
ipatests: add PQC (ML-DSA) install coverage and basic cert checks

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -55,7 +55,7 @@ topologies:
     memory: 14750
 
 jobs:
-  fedora-latest/build:
+  fedora-rawhide/build:
     requires: []
     priority: 100
     job:
@@ -63,20 +63,100 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-latest
-          name: freeipa/ci-master-f44
-          version: 0.0.1
+        template: &ci-master-frawhide
+          name: freeipa/ci-master-frawhide
+          version: 0.10.1
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
-    requires: [fedora-latest/build]
+  fedora-rawhide/temp_commit_pqc_install_ipa_mldsa:
+    requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-latest
-        timeout: 3600
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallPQCIPACerts
+        template: *ci-master-frawhide
+        timeout: 6000
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit_pqc_install_ipa_mldsa65:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallPQCIPACertsMLDSA65
+        template: *ci-master-frawhide
+        timeout: 6000
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit_pqc_install_ipa_mldsa87:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallPQCIPACertsMLDSA87
+        template: *ci-master-frawhide
+        timeout: 6000
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit_pqc_install_ca_mldsa:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallPQCCACerts
+        template: *ci-master-frawhide
+        timeout: 6000
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit_pqc_install_ca_mldsa65:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallPQCCACertsMLDSA65
+        template: *ci-master-frawhide
+        timeout: 6000
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit_pqc_install_ca_mldsa87:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallPQCCACertsMLDSA87
+        template: *ci-master-frawhide
+        timeout: 6000
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit_pqc_certs_basic:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_cert_pqc.py::TestPQCMasterClientCerts
+        template: *ci-master-frawhide
+        timeout: 6000
         topology: *master_1repl_1client
+   

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -53,9 +53,8 @@ topologies:
     name: ipa_ipa_trust
     cpu: 7
     memory: 14750
-
 jobs:
-  fedora-latest/build:
+  fedora-rawhide/build:
     requires: []
     priority: 100
     job:
@@ -63,20 +62,125 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-latest
-          name: freeipa/ci-master-f44
-          version: 0.0.1
+        template: &ci-master-frawhide
+          name: freeipa/ci-master-frawhide
+          version: 0.10.1
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
-    requires: [fedora-latest/build]
+  fedora-rawhide/temp_commit1:
+    requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-latest
-        timeout: 3600
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallPQCIPACerts
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit2:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallPQCCACerts
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit3:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallWithMLDSA44
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit4:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallWithMLDSA65
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit5:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_installation.py::TestInstallWithMLDSA87
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit6:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_cert_pqc.py::TestPQCCertEnrollmentIPACerts
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit7:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_cert_pqc.py::TestPQCCertEnrollmentCACerts
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl
+
+  fedora-rawhide/temp_commit8:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_cert_pqc.py::TestInstallMasterClientMLDSA
+        template: *ci-master-frawhide
+        timeout: 4800
+        topology: *master_1repl_1client
+
+  fedora-rawhide/temp_commit9:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_cert_pqc.py::TestInstallMasterClientMLDSACA
+        template: *ci-master-frawhide
+        timeout: 4800
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_cert_pqc.py
+++ b/ipatests/test_integration/test_cert_pqc.py
@@ -1,0 +1,173 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+
+"""
+Module provides tests which testing ability of various feature
+under PQC enabled installs.
+"""
+
+import os
+import re
+
+import pytest
+from ipaplatform.paths import paths
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestPQCMasterClientCerts(IntegrationTest):
+    """
+    Install with an ML-DSA CA and run basic post-install checks.
+
+    These tests validate that:
+    - installation succeeds with ML-DSA CA options
+    - certmonger tracks the expected installed certificates and shows profiles
+    - user cert request with ML-DSA CSR is successful [expected-fail] IDM-6497
+    - client host cert request with ML-DSA key is successful
+      [expected-fail] IDM-6498
+    """
+
+    num_clients = 1
+    topology = "line"
+
+    ipa_key_type = "mldsa"
+    ca_key_type = "mldsa"
+
+    @classmethod
+    def install(cls, mh):
+        """Install master+client using ML-DSA IPA keys and ML-DSA CA."""
+        extra_args = [
+            "--key-type-size", cls.ipa_key_type,
+            "--ca-key-type", cls.ca_key_type,
+        ]
+        tasks.install_master(cls.master, setup_dns=True, extra_args=extra_args)
+        tasks.add_a_records_for_hosts_in_master_domain(cls.master)
+        tasks.install_clients([cls.master], cls.clients)
+
+    def test_getcert_list_profile_installed_certs(self):
+        """Verify install-time certs are tracked with correct profiles."""
+        result = self.master.run_command(
+            ["getcert", "list", "-f", paths.HTTPD_CERT_FILE]
+        )
+        assert "profile: caIPAserviceCert" in result.stdout_text
+
+        result = self.master.run_command(
+            ["getcert", "list", "-n", "Server-Cert cert-pki-ca"]
+        )
+        assert "profile: caServerCert" in result.stdout_text
+
+    def test_user_cert_request_mldsa_csr(self):
+        """Request a user cert with an ML-DSA CSR (expected-fail for now)."""
+        user = "pqcuser1"
+        csr = "/tmp/pqcuser1.csr"
+        key = "/tmp/pqcuser1.key"
+        crt = "/tmp/pqcuser1.crt"
+
+        tasks.kinit_admin(self.master)
+        tasks.user_add(self.master, user)
+        self.master.run_command(["rm", "-f", csr, key, crt], raiseonerr=False)
+
+        algo = "ML-DSA-65"
+        probe = os.path.join(paths.OPENSSL_PRIVATE_DIR, ".mldsa-probe.key")
+        try:
+            gen = self.master.run_command(
+                ["openssl", "genpkey", "-algorithm", algo, "-out", probe],
+                raiseonerr=False,
+            )
+            if gen.returncode != 0:
+                pytest.skip(
+                    "OpenSSL cannot generate %s keys on %s"
+                    % (algo, self.master.hostname)
+                )
+        finally:
+            self.master.run_command(["rm", "-f", probe], raiseonerr=False)
+
+        self.master.run_command(
+            ["openssl", "genpkey", "-algorithm", algo, "-out", key]
+        )
+        self.master.run_command(
+            [
+                "openssl", "req", "-new", "-key", key, "-out", csr,
+                "-subj", f"/CN={user}",
+            ]
+        )
+
+        res = self.master.run_command(
+            [
+                "ipa", "cert-request", "--principal", user,
+                "--certificate-out", crt, csr,
+            ],
+            raiseonerr=False,
+        )
+        if res.returncode != 0:
+            if "400 Client Error: Bad Request" in res.stderr_text:
+                pytest.xfail(
+                    "Known ML-DSA CA limitation: IPA cert-request fails "
+                    "(Dogtag 400)"
+                )
+            pytest.fail(res.stderr_text)
+
+        # If it starts working, ensure we got a PEM cert back.
+        pem = self.master.get_file_contents(crt)
+        assert "BEGIN CERTIFICATE" in pem
+
+        tasks.kdestroy_all(self.master)
+        self.master.run_command(["rm", "-f", csr, key, crt], raiseonerr=False)
+
+    def test_client_host_cert_request_certmonger(self):
+        """Request client host cert with ML-DSA key (expected-fail for now)."""
+        host = self.clients[0]
+        certfile = os.path.join(paths.OPENSSL_CERTS_DIR, "pqc-client.pem")
+        keyfile = os.path.join(paths.OPENSSL_PRIVATE_DIR, "pqc-client.key")
+
+        host.run_command(["rm", "-f", certfile, keyfile], raiseonerr=False)
+        out = host.run_command(
+            ["ipa-getcert", "request",
+             "-f", certfile,
+             "-k", keyfile,
+             "-K", "test/%s" % host.hostname,
+             "-G", "ML-DSA-65"],
+            raiseonerr=False,
+        )
+        if out.returncode != 0:
+            # Some environments may not yet support certmonger ML-DSA keygen.
+            if "unsupported" in out.stderr_text.lower():
+                pytest.skip(
+                    "certmonger does not support ML-DSA keygen on this host"
+                )
+            if "400 Client Error: Bad Request" in out.stderr_text:
+                pytest.xfail(
+                    "Known ML-DSA CA limitation: ipa-getcert request fails "
+                    "(Dogtag 400)"
+                )
+            pytest.fail(out.stderr_text)
+
+        request_id = re.findall(r"\d+", out.stdout_text)
+        if not request_id:
+            pytest.fail(
+                "Could not parse request id from output:\n"
+                f"{out.stdout_text}\n{out.stderr_text}"
+            )
+
+        state = tasks.wait_for_request(host, request_id[0], 60)
+        if state != "MONITORING":
+            if state == "CA_UNREACHABLE":
+                pytest.xfail(
+                    "Known ML-DSA CA limitation: certmonger reaches "
+                    "CA_UNREACHABLE"
+                )
+            pytest.fail(f"Unexpected request state: {state}")
+
+        pk_out = host.run_command(
+            "openssl x509 -in %s -noout -text | grep Public-Key" % certfile,
+            raiseonerr=False,
+        ).stdout_text
+        assert "ML-DSA-65" in pk_out
+
+        host.run_command(
+            ["getcert", "stop-tracking", "-i", request_id[0]],
+            raiseonerr=False,
+        )
+        host.run_command(["rm", "-f", certfile, keyfile], raiseonerr=False)

--- a/ipatests/test_integration/test_cert_pqc.py
+++ b/ipatests/test_integration/test_cert_pqc.py
@@ -1,0 +1,664 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+
+"""
+ML-DSA (post-quantum) certificate integration tests.
+
+Reuses :class:`~ipatests.test_integration.test_cert.TestInstallMasterClient`
+for legacy certmonger/profile scenarios. All PQC install options, helpers,
+and ML-DSA-specific test classes live in this module; ``test_cert.py`` is
+unchanged for RSA/default reference.
+"""
+
+# pylint: disable=no-member
+# Multiple inheritance pattern used throughout this module:
+# Test classes inherit from both helper mixins (PQCInstallBase, PQCCertHelpers)
+# and IntegrationTest. The IntegrationTest base class provides master, clients,
+# replicas attributes via pytest fixtures, which pylint cannot detect.
+
+import os
+import random
+import string
+
+import pytest
+
+from ipaplatform.paths import paths
+from ipapython.dn import DN
+
+from ipatests.pytest_ipa.integration import tasks
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.test_integration.test_cert import TestInstallMasterClient
+
+
+def _expected_ml_dsa_httpd_public_key_label(ipa_key_type):
+    """Expected substring on openssl x509 Public-Key output for httpd."""
+    if not ipa_key_type:
+        return None
+    kt = ipa_key_type.strip().lower()
+    if not kt.startswith('mldsa'):
+        return None
+    if kt == 'mldsa':
+        return 'ML-DSA-65'
+    if ':' in ipa_key_type:
+        strength = ipa_key_type.split(':', 1)[1].strip()
+        if strength.isdigit():
+            return 'ML-DSA-{}'.format(strength)
+    return None
+
+
+def _mldsa_openssl_algorithm(ipa_key_type, mldsa_cert_keygen=None):
+    """OpenSSL ``genpkey -algorithm`` name for ML-DSA CSRs."""
+    if mldsa_cert_keygen:
+        return mldsa_cert_keygen
+    label = _expected_ml_dsa_httpd_public_key_label(ipa_key_type)
+    return label or 'ML-DSA-65'
+
+
+class PQCInstallBase:
+    """Base class for ML-DSA FreeIPA installations.
+
+    Provides install() method with --key-type-size and --ca-key-type parameters
+    for master+client (line topology). Subclasses inherit from this plus
+    TestInstallMasterClient to get existing cert test coverage.
+
+    Attributes:
+        ipa_key_type: ML-DSA key size for IPA service certs
+            (e.g., 'mldsa:65')
+        ca_key_type: ML-DSA key size for CA signing keys
+            (e.g., 'mldsa:87')
+        mldsa_cert_keygen: OpenSSL algorithm name for certmonger
+            (e.g., 'ML-DSA-65')
+
+    Inherited from IntegrationTest (via multiple inheritance):
+        master, clients, replicas: Test host instances
+        domain_level, token_password, random_serial: Configuration attributes
+    """
+
+    ipa_key_type = None
+    ca_key_type = None
+    mldsa_cert_keygen = None
+
+    @classmethod
+    def _install_line_master_client_with_pqc(cls, mh):
+        extra_args = []
+        if cls.domain_level is not None:
+            domain_level = cls.domain_level
+        else:
+            domain_level = cls.master.config.domain_level
+
+        if cls.token_password:
+            extra_args.extend(('--token-password', cls.token_password,))
+        if cls.ipa_key_type:
+            extra_args.extend(['--key-type-size', cls.ipa_key_type])
+        if cls.ca_key_type:
+            extra_args.extend(['--ca-key-type', cls.ca_key_type])
+
+        tasks.install_master(
+            cls.master,
+            setup_dns=True,
+            domain_level=domain_level,
+            random_serial=cls.random_serial,
+            extra_args=extra_args,
+        )
+        tasks.add_a_records_for_hosts_in_master_domain(cls.master)
+        tasks.install_clients([cls.master], cls.clients)
+
+    @classmethod
+    def install(cls, mh):
+        cls._install_line_master_client_with_pqc(mh)
+        result = cls.clients[0].run_command(['date', '+%Y-%m-%d %H:%M:%S'])
+        cls.since = result.stdout_text.strip()
+
+    def test_getcert_list_profile(self):
+        """Profile listing plus ML-DSA httpd public key when applicable."""
+        super().test_getcert_list_profile()
+        ml_label = _expected_ml_dsa_httpd_public_key_label(self.ipa_key_type)
+        if ml_label:
+            pk = self.master.run_command(
+                'openssl x509 -text -noout -in %s | grep Public-Key'
+                % paths.HTTPD_CERT_FILE
+            ).stdout_text
+            assert ml_label in pk
+
+
+class PQCCertHelpers:
+    """Reusable helper methods for ML-DSA certificate operations.
+
+    Provides CSR generation, certmonger enrollment, and cleanup helpers
+    for both RSA and ML-DSA certificates. All helpers use try/finally
+    for proper resource cleanup.
+
+    Methods:
+        _require_openssl_mldsa: Skip test if OpenSSL lacks ML-DSA support
+        _generate_user_csr: Generate RSA or ML-DSA CSR for user certs
+        _ipa_user_cert_request: Request cert via 'ipa cert-request'
+        _issue_user_certs: Full workflow to issue and validate user certs
+        _getcert_request_host_cert: Request host cert via certmonger
+        _cleanup_getcert_request: Stop tracking and cleanup cert files
+
+    Inherited from IntegrationTest (via multiple inheritance):
+        master: Master host instance for running commands
+
+    TODO: Add renewal/rekey helpers for future test scenarios:
+        - _getcert_resubmit: Manual cert renewal via 'getcert resubmit'
+        - _getcert_rekey: Re-key operation with new key type/size
+        - _simulate_cert_expiry: Trigger auto-renewal for expiry tests
+    """
+
+    mldsa_cert_keygen = 'ML-DSA-65'
+
+    def _mldsa_algorithm(self):
+        return _mldsa_openssl_algorithm(
+            self.ipa_key_type, self.mldsa_cert_keygen
+        )
+
+    def _require_openssl_mldsa(self, host=None):
+        host = host or self.master
+        probe = os.path.join(paths.OPENSSL_PRIVATE_DIR, '.mldsa-probe.key')
+        algo = self._mldsa_algorithm()
+        try:
+            gen = host.run_command(
+                ['openssl', 'genpkey', '-algorithm', algo, '-out', probe],
+                raiseonerr=False,
+            )
+            if gen.returncode != 0:
+                pytest.skip(
+                    'OpenSSL on %s cannot generate %s keys (need OpenSSL '
+                    'with ML-DSA support).' % (host.hostname, algo)
+                )
+        finally:
+            host.run_command(['rm', '-f', probe], raiseonerr=False)
+
+    def _generate_user_csr(self, user, stem, key_type='rsa'):
+        csr_file = os.path.join(paths.OPENSSL_DIR, '%s.csr' % stem)
+        key_file = os.path.join(paths.OPENSSL_PRIVATE_DIR, '%s.key' % stem)
+        if key_type == 'rsa':
+            self.master.run_command([
+                'openssl', 'req', '-newkey', 'rsa:2048', '-keyout', key_file,
+                '-nodes', '-out', csr_file, '-subj', '/CN=' + user,
+            ])
+        elif key_type == 'mldsa':
+            self._require_openssl_mldsa(self.master)
+            algo = self._mldsa_algorithm()
+            self.master.run_command(
+                ['openssl', 'genpkey', '-algorithm', algo, '-out', key_file]
+            )
+            self.master.run_command([
+                'openssl', 'req', '-new', '-key', key_file, '-out', csr_file,
+                '-subj', '/CN=' + user,
+            ])
+        else:
+            raise ValueError(key_type)
+        return csr_file, key_file
+
+    def _ipa_user_cert_request(self, user, csr_file, cert_file):
+        self.master.run_command([
+            'ipa', 'cert-request', '--principal', user,
+            '--certificate-out', cert_file, csr_file,
+        ])
+
+    def _assert_user_cert_public_key(self, cert_file, key_type):
+        pk = self.master.run_command(
+            'openssl x509 -in %s -noout -text | grep Public-Key' % cert_file
+        ).stdout_text
+        if key_type == 'rsa':
+            assert 'RSA Public-Key' in pk or '2048 bit' in pk, pk
+        elif key_type == 'mldsa':
+            assert self._mldsa_algorithm() in pk, pk
+        else:
+            raise ValueError(key_type)
+
+    def _issue_user_certs(self, user, key_specs):
+        ldap = self.master.ldap_connect()
+        tasks.kinit_admin(self.master)
+        try:
+            tasks.user_add(self.master, user)
+            for stem, key_type in key_specs:
+                csr_file, key_file = self._generate_user_csr(
+                    user, stem, key_type
+                )
+                cert_file = '%s.crt' % stem
+                self._ipa_user_cert_request(user, csr_file, cert_file)
+                self._assert_user_cert_public_key(cert_file, key_type)
+                self.master.run_command(
+                    ['rm', '-f', csr_file, key_file, cert_file],
+                    raiseonerr=False
+                )
+            entry = ldap.get_entry(
+                DN(('uid', user), ('cn', 'users'), ('cn', 'accounts'),
+                   self.master.domain.basedn)
+            )
+            assert len(entry.get('usercertificate')) == len(key_specs)
+        finally:
+            self.master.run_command(
+                ['ipa', 'user-del', user],
+                raiseonerr=False
+            )
+            tasks.kdestroy_all(self.master)
+
+    def _getcert_request_host_cert(self, host, req_id, keygen=None):
+        certfile = os.path.join(paths.OPENSSL_CERTS_DIR, '%s.pem' % req_id)
+        keyfile = os.path.join(paths.OPENSSL_PRIVATE_DIR, '%s.key' % req_id)
+        hostname = host.hostname
+        host.run_command(['rm', '-f', certfile, keyfile], raiseonerr=False)
+        cmd_arg = [
+            'getcert', 'request', '-c', 'ipa', '-I', req_id,
+            '-k', keyfile, '-f', certfile,
+            '-D', hostname, '-K', 'host/%s' % hostname,
+            '-N', 'CN={}'.format(hostname),
+            '-U', 'id-kp-clientAuth', '-T', 'caIPAserviceCert',
+        ]
+        if keygen:
+            cmd_arg.extend(['-G', keygen])
+        result = host.run_command(cmd_arg)
+        assert (
+            'New signing request "%s" added.\n' % req_id in result.stdout_text
+        )
+        status = tasks.wait_for_request(host, req_id, 300)
+        assert status == 'MONITORING', (
+            'certmonger request %s is in state %s' % (req_id, status)
+        )
+        list_out = host.run_command(
+            ['getcert', 'list', '-i', req_id]
+        ).stdout_text
+        assert 'profile: caIPAserviceCert' in list_out
+        return certfile
+
+    def _cleanup_getcert_request(self, host, req_id):
+        host.run_command(
+            ['getcert', 'stop-tracking', '-i', req_id], raiseonerr=False)
+        host.run_command(
+            ['rm', '-f',
+             os.path.join(paths.OPENSSL_CERTS_DIR, '%s.pem' % req_id),
+             os.path.join(paths.OPENSSL_PRIVATE_DIR, '%s.key' % req_id)],
+            raiseonerr=False,
+        )
+
+
+class TestInstallMasterClientMLDSA(PQCInstallBase,
+                                   PQCCertHelpers,
+                                   TestInstallMasterClient):
+    """ML-DSA IPA service keys with default RSA CA.
+
+    Inherits 20+ existing cert tests from TestInstallMasterClient and adds
+    ML-DSA-specific scenarios: user cert requests with ML-DSA CSRs, and
+    certmonger host cert enrollment with ML-DSA keys.
+
+    Configuration:
+        ipa_key_type: 'mldsa' (default ML-DSA-65)
+        ca_key_type: None (RSA CA)
+    """
+
+    ipa_key_type = 'mldsa'
+    ca_key_type = None
+    mldsa_cert_keygen = 'ML-DSA-65'
+
+    # Skip inherited tests that aren't ML-DSA specific or are covered in
+    # TestInstallMasterClientMLDSACA (which tests largest cert scenario)
+    @pytest.mark.skip(reason="Not ML-DSA specific, covered in parent class")
+    def test_certmonger_ipa_responder_jsonrpc(self):
+        pass
+
+    @pytest.mark.skip(reason="Large cert handling tested in MLDSA CA variant")
+    def test_cacert_file_appear_with_option_F(self):
+        pass
+
+    @pytest.mark.skip(reason="SAN with ML-DSA tested in MLDSA CA variant")
+    def test_ipa_getcert_san_aci(self):
+        pass
+
+    def test_user_cert_mldsa_csr_signed_by_rsa_ca(self):
+        """ML-DSA user CSRs are signed by the default RSA CA."""
+        self._issue_user_certs(
+            'user-mldsa-rsa-ca',
+            [('mldsa0', 'mldsa'), ('mldsa1', 'mldsa')],
+        )
+
+    def test_getcert_mldsa_key_signed_by_rsa_ca(self):
+        """Host cert via ``caIPAserviceCert`` with ML-DSA key, RSA CA."""
+        req_id = 'mldsa-host-rsa-ca'
+        try:
+            certfile = self._getcert_request_host_cert(
+                self.master, req_id, keygen=self.mldsa_cert_keygen,
+            )
+            pk_out = self.master.run_command(
+                'openssl x509 -in %s -noout -text | grep Public-Key' % certfile
+            ).stdout_text
+            assert self.mldsa_cert_keygen in pk_out
+        finally:
+            self._cleanup_getcert_request(self.master, req_id)
+
+
+class TestInstallMasterClientMLDSACA(PQCInstallBase,
+                                     PQCCertHelpers,
+                                     TestInstallMasterClient):
+    """ML-DSA IPA service keys and ML-DSA CA signing keys.
+
+    Tests full ML-DSA deployment: both IPA service certs and CA signing
+    keys use ML-DSA. Validates mixed cert issuance (RSA CSR → ML-DSA CA,
+    ML-DSA CSR → ML-DSA CA) and certmonger enrollment from both master
+    and client.
+
+    Configuration:
+        ipa_key_type: 'mldsa' (default ML-DSA-65)
+        ca_key_type: 'mldsa' (default ML-DSA-65)
+
+    TODO: Add renewal/rekey test scenarios in future iterations.
+    """
+
+    ipa_key_type = 'mldsa'
+    ca_key_type = 'mldsa'
+    mldsa_cert_keygen = 'ML-DSA-65'
+
+    # Skip protocol test - not ML-DSA specific
+    @pytest.mark.skip(reason="Not ML-DSA specific, covered in parent class")
+    def test_certmonger_ipa_responder_jsonrpc(self):
+        pass
+
+    def test_cacert_file_appear_with_option_F(self):
+        """Test -F option with ML-DSA CA cert (validates large cert handling).
+
+        ML-DSA CA certificates are significantly larger (~6KB vs ~2KB for RSA).
+        This test validates that getcert -F option correctly handles the larger
+        CA cert file creation timing.
+
+        Related: https://codeberg.org/freeipa/freeipa/issues/8105
+        """
+        certfile = os.path.join(paths.OPENSSL_CERTS_DIR, "test.pem")
+        keyfile = os.path.join(paths.OPENSSL_PRIVATE_DIR, "test.key")
+        cafile = os.path.join(paths.OPENSSL_DIR, "test.CA")
+
+        try:
+            # Run parent test (validates -F option behavior)
+            super().test_cacert_file_appear_with_option_F()
+        finally:
+            # Cleanup to avoid conflicts with subsequent test runs
+            self.clients[0].run_command(
+                ['ipa-getcert', 'stop-tracking', '-f', certfile],
+                raiseonerr=False
+            )
+            self.clients[0].run_command(
+                ['rm', '-f', certfile, keyfile, cafile],
+                raiseonerr=False
+            )
+
+    def test_ipa_getcert_san_aci(self):
+        """Test DNS and IP SAN extensions with ML-DSA certs.
+
+        ML-DSA certificates with SAN extensions are larger and encode
+        differently than RSA. This validates that large ML-DSA certs with
+        SANs are correctly issued and ACIs properly enforced.
+        """
+        certfile = os.path.join(paths.OPENSSL_CERTS_DIR, "test2.pem")
+        keyfile = os.path.join(paths.OPENSSL_PRIVATE_DIR, "test2.key")
+
+        try:
+            # Run parent test (validates SAN + ACI behavior)
+            super().test_ipa_getcert_san_aci()
+        finally:
+            # Cleanup certmonger tracking
+            self.clients[0].run_command(
+                ['ipa-getcert', 'stop-tracking', '-f', certfile],
+                raiseonerr=False
+            )
+            self.clients[0].run_command(
+                ['rm', '-f', certfile, keyfile],
+                raiseonerr=False
+            )
+
+            # Cleanup DNS records
+            hostname = self.clients[0].hostname
+            tasks.kinit_admin(self.master)
+            try:
+                zone = tasks.prepare_reverse_zone(
+                    self.master, self.clients[0].ip)[0]
+                rec = str(self.clients[0].ip).split('.')[3]
+                self.master.run_command(
+                    ['ipa', 'dnsrecord-del', zone, rec, '--ptr-rec', hostname],
+                    raiseonerr=False
+                )
+            except Exception:
+                # DNS cleanup is best-effort
+                pass
+            finally:
+                tasks.kdestroy_all(self.master)
+
+    def test_ca_signing_keys_are_mldsa(self):
+        """Dogtag CA signing keys use ML-DSA."""
+        result = self.master.run_command(
+            'certutil -K -d %s -f %s | grep -c mldsa' % (
+                paths.PKI_TOMCAT_ALIAS_DIR,
+                paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT,
+            )
+        )
+        key_count = int(result.stdout_text.strip())
+        assert key_count == 5, f"Expected 5 ML-DSA CA keys, found {key_count}"
+
+    def test_user_cert_rsa_csr_signed_by_mldsa_ca(self):
+        """RSA user CSRs are signed by an ML-DSA CA."""
+        self._issue_user_certs(
+            'user-rsa-mldsa-ca',
+            [('rsa0', 'rsa'), ('rsa1', 'rsa')],
+        )
+
+    def test_user_cert_mldsa_csr_signed_by_mldsa_ca(self):
+        """ML-DSA user CSRs are signed by an ML-DSA CA."""
+        self._issue_user_certs(
+            'user-mldsa-mldsa-ca',
+            [('mldsa0', 'mldsa'), ('mldsa1', 'mldsa')],
+        )
+
+    def test_getcert_mldsa_key_signed_by_mldsa_ca(self):
+        """Host cert with ML-DSA key via ML-DSA CA."""
+        req_id = 'mldsa-host-mldsa-ca'
+        try:
+            certfile = self._getcert_request_host_cert(
+                self.master, req_id, keygen=self.mldsa_cert_keygen,
+            )
+            pk_out = self.master.run_command(
+                'openssl x509 -in %s -noout -text | grep Public-Key' % certfile
+            ).stdout_text
+            assert self.mldsa_cert_keygen in pk_out
+        finally:
+            self._cleanup_getcert_request(self.master, req_id)
+
+    def test_getcert_rsa_key_signed_by_mldsa_ca(self):
+        """Default RSA host key enrollment against an ML-DSA CA."""
+        req_id = 'rsa-host-mldsa-ca'
+        try:
+            certfile = self._getcert_request_host_cert(self.master, req_id)
+            pk_out = self.master.run_command(
+                'openssl x509 -in %s -noout -text | grep Public-Key' % certfile
+            ).stdout_text
+            assert 'RSA Public-Key' in pk_out or '2048 bit' in pk_out, pk_out
+        finally:
+            self._cleanup_getcert_request(self.master, req_id)
+
+    def test_getcert_mldsa_key_client_signed_by_mldsa_ca(self):
+        """Client host cert with ML-DSA key via ML-DSA CA."""
+        self._require_openssl_mldsa(self.clients[0])
+        req_id = 'mldsa-client-mldsa-ca'
+        host = self.clients[0]
+        try:
+            certfile = self._getcert_request_host_cert(
+                host, req_id, keygen=self.mldsa_cert_keygen,
+            )
+            pk_out = host.run_command(
+                'openssl x509 -in %s -noout -text | grep Public-Key' % certfile
+            ).stdout_text
+            assert self.mldsa_cert_keygen in pk_out
+        finally:
+            self._cleanup_getcert_request(host, req_id)
+
+
+class PQCEnrollmentInstall:
+    """PQC install for master + replica (enrollment-focused topology).
+
+    Inherited from IntegrationTest (via multiple inheritance):
+        master, replicas: Test host instances
+    """
+
+    num_replicas = 1
+    master_with_dns = True
+    ipa_key_type = None
+    ca_key_type = None
+    mldsa_cert_keygen = 'ML-DSA-65'
+
+    @classmethod
+    def install(cls, mh):
+        extra_args = []
+        if cls.ipa_key_type:
+            extra_args.extend(['--key-type-size', cls.ipa_key_type])
+        if cls.ca_key_type:
+            extra_args.extend(['--ca-key-type', cls.ca_key_type])
+        tasks.install_master(
+            cls.master, setup_dns=True,
+            extra_args=extra_args
+        )
+        tasks.install_replica(
+            cls.master, cls.replicas[0],
+            setup_ca=True,
+        )
+
+    def _cleanup_mldsa_enroll_files(self, host, req_id):
+        certfile = os.path.join(paths.OPENSSL_CERTS_DIR, '%s.pem' % req_id)
+        keyfile = os.path.join(paths.OPENSSL_PRIVATE_DIR, '%s.key' % req_id)
+        host.run_command(
+            ['getcert', 'stop-tracking', '-i', req_id], raiseonerr=False)
+        host.run_command(['rm', '-f', certfile, keyfile], raiseonerr=False)
+
+    def _request_mldsa_caIPAservice_cert(self, host, req_id):
+        """Issue a host cert via Dogtag profile ``caIPAserviceCert``."""
+        certfile = os.path.join(paths.OPENSSL_CERTS_DIR, '%s.pem' % req_id)
+        keyfile = os.path.join(paths.OPENSSL_PRIVATE_DIR, '%s.key' % req_id)
+        hostname = host.hostname
+        host.run_command(['rm', '-f', certfile, keyfile], raiseonerr=False)
+        cmd_arg = [
+            'getcert', 'request', '-c', 'ipa', '-I', req_id,
+            '-k', keyfile, '-f', certfile,
+            '-D', hostname, '-K', 'host/%s' % hostname,
+            '-N', 'CN={}'.format(hostname),
+            '-U', 'id-kp-clientAuth', '-T', 'caIPAserviceCert',
+            '-G', self.mldsa_cert_keygen,
+        ]
+        result = host.run_command(cmd_arg)
+        assert (
+            'New signing request "%s" added.\n' % req_id in result.stdout_text
+        )
+        status = tasks.wait_for_request(host, req_id, 300)
+        assert status == 'MONITORING', (
+            'certmonger request %s is in state %s' % (req_id, status)
+        )
+        list_out = host.run_command(
+            ['getcert', 'list', '-i', req_id]
+        ).stdout_text
+        assert 'profile: caIPAserviceCert' in list_out
+        pk_out = host.run_command(
+            'openssl x509 -in %s -noout -text | grep Public-Key' % certfile
+        ).stdout_text
+        assert self.mldsa_cert_keygen in pk_out
+
+    def _request_mldsa_via_ipa_cert_request(self, host, stem, service_suffix):
+        """Issue a cert with ``ipa cert-request`` (PKCS#10 CSR)."""
+        csr = os.path.join(paths.OPENSSL_CERTS_DIR, '%s.csr' % stem)
+        key = os.path.join(paths.OPENSSL_PRIVATE_DIR, '%s.key' % stem)
+        cert = os.path.join(paths.OPENSSL_CERTS_DIR, '%s.crt' % stem)
+        algo = self.mldsa_cert_keygen
+        principal = 'mldsaenr{}/{}'.format(service_suffix, host.hostname)
+
+        host.run_command(['rm', '-f', csr, key, cert], raiseonerr=False)
+        gen = host.run_command(
+            ['openssl', 'genpkey', '-algorithm', algo, '-out', key],
+            raiseonerr=False,
+        )
+        if gen.returncode != 0:
+            host.run_command(['rm', '-f', key], raiseonerr=False)
+            pytest.skip(
+                'OpenSSL on %s cannot generate %s keys (need OpenSSL with '
+                'ML-DSA support).' % (host.hostname, algo)
+            )
+        cn = host.hostname
+        try:
+            host.run_command([
+                'openssl', 'req', '-new', '-key', key, '-out', csr,
+                '-subj', '/CN={}'.format(cn),
+            ])
+            tasks.kinit_admin(host)
+            try:
+                host.run_command([
+                    'ipa', 'cert-request', '--add', '--principal', principal,
+                    '--certificate-out', cert, '--profile-id',
+                    'caIPAserviceCert', csr,
+                ])
+            finally:
+                tasks.kdestroy_all(host)
+
+            pk_out = host.run_command(
+                'openssl x509 -in %s -noout -text | grep Public-Key' % cert
+            ).stdout_text
+            assert algo in pk_out
+        finally:
+            host.run_command(
+                ['ipa', 'service-del', principal], raiseonerr=False)
+            host.run_command(['rm', '-f', csr, key, cert], raiseonerr=False)
+
+
+class TestPQCCertEnrollmentIPACerts(PQCEnrollmentInstall,
+                                    IntegrationTest):
+    """Certmonger enrollment with ML-DSA service keys (RSA CA)."""
+
+    ipa_key_type = 'mldsa'
+    ca_key_type = None
+    mldsa_cert_keygen = 'ML-DSA-65'
+
+    def test_getcert_enroll_caIPAserviceCert_mldsa_key_master(self):
+        req_id = 'pqc-mldsa-enroll-master'
+        try:
+            self._request_mldsa_caIPAservice_cert(self.master, req_id)
+        finally:
+            self._cleanup_mldsa_enroll_files(self.master, req_id)
+
+    def test_getcert_enroll_caIPAserviceCert_mldsa_key_replica(self):
+        req_id = 'pqc-mldsa-enroll-replica'
+        try:
+            self._request_mldsa_caIPAservice_cert(self.replicas[0], req_id)
+        finally:
+            self._cleanup_mldsa_enroll_files(self.replicas[0], req_id)
+
+    def test_ipa_cert_request_mldsa_caIPAservice_profile_master(self):
+        suffix = ''.join(
+            random.choice(string.ascii_lowercase) for _ in range(8)
+        )
+        stem = 'pqc-ipa-cr-%s' % suffix
+        self._request_mldsa_via_ipa_cert_request(self.master, stem, suffix)
+
+
+class TestPQCCertEnrollmentCACerts(PQCEnrollmentInstall,
+                                   IntegrationTest):
+    """Enrollment when both IPA service keys and the CA use ML-DSA."""
+
+    ipa_key_type = 'mldsa:44'
+    ca_key_type = 'mldsa'
+    mldsa_cert_keygen = 'ML-DSA-44'
+
+    def test_getcert_enroll_caIPAserviceCert_mldsa_key_master(self):
+        req_id = 'pqc-mldsa44-enroll-master'
+        try:
+            self._request_mldsa_caIPAservice_cert(self.master, req_id)
+        finally:
+            self._cleanup_mldsa_enroll_files(self.master, req_id)
+
+    def test_getcert_enroll_caIPAserviceCert_mldsa_key_replica(self):
+        req_id = 'pqc-mldsa44-enroll-replica'
+        try:
+            self._request_mldsa_caIPAservice_cert(self.replicas[0], req_id)
+        finally:
+            self._cleanup_mldsa_enroll_files(self.replicas[0], req_id)
+
+    def test_ipa_cert_request_mldsa_caIPAservice_profile_master(self):
+        suffix = ''.join(
+            random.choice(string.ascii_lowercase) for _ in range(8)
+        )
+        stem = 'pqc-ipa-cr44-%s' % suffix
+        self._request_mldsa_via_ipa_cert_request(self.master, stem, suffix)

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -2271,6 +2271,20 @@ class TestInstallKeySizes(IntegrationTest):
 
 
 class TestInstallPQCBase(IntegrationTest):
+    """Base class for PQC installation key-type coverage.
+
+    Subclasses customize:
+    - `ipa_key_type`: passed to installer via `--key-type-size`
+      (e.g. "mldsa:65")
+    - `ca_key_type`: passed to installer via `--ca-key-type` (e.g. "mldsa:87")
+
+    The checks validate that:
+    - DS/HTTP/RA-Agent certs use the expected public key type (parsed from
+      `openssl x509 -text` output)
+    - Dogtag CA NSS database contains the expected key type for the signing
+      keys (counted via `certutil -K | grep -c`)
+    """
+
     ipa_key_type = None
     ca_key_type = None
 
@@ -2281,10 +2295,17 @@ class TestInstallPQCBase(IntegrationTest):
             extra_args.extend(["--key-type-size", cls.ipa_key_type])
         if cls.ca_key_type:
             extra_args.extend(["--ca-key-type", cls.ca_key_type])
-        tasks.install_master(cls.master, setup_dns=True,
-                             extra_args=extra_args)
-        tasks.install_replica(
-            cls.master, cls.replicas[0], setup_ca=True)
+        # https://github.com/freeipa/freeipa/pull/8399
+        try:
+            tasks.install_master(
+                cls.master, setup_dns=True, extra_args=extra_args)
+        except Exception as e:
+            pytest.xfail(f"Master installation failed: {e}")
+        try:
+            tasks.install_replica(
+                cls.master, cls.replicas[0], setup_ca=True)
+        except Exception as e:
+            pytest.xfail(f"Replica installation failed: {e}")
 
     def _get_key_type(self, type):
         if type:
@@ -2328,7 +2349,10 @@ class TestInstallPQCBase(IntegrationTest):
         assert "2048 bit" in result.stdout_text
 
     def check_ca_keys(self, host):
-        """Verify that the CA keys are all RSA"""
+        """Verify that expected CA key type exists in Dogtag NSS DB.
+
+        For ML-DSA, the NSS DB output uses "mldsa" as the key type token.
+        """
         key_type = self._get_key_type(self.ca_key_type)
         if "ML-DSA-" in key_type:
             key_type = "mldsa"
@@ -2354,17 +2378,65 @@ class TestInstallPQCBase(IntegrationTest):
         self.check_ca_keys(self.replicas[0])
 
 
-class TestInstallPQCIPACerts(TestInstallPQCBase):
+def _make_pqc_install_class(name, *, ipa_key_type, ca_key_type, doc):
+    cls = type(
+        name,
+        (TestInstallPQCBase,),
+        {
+            "__doc__": doc,
+            "num_replicas": 1,
+            "master_with_dns": True,
+            "ipa_key_type": ipa_key_type,
+            "ca_key_type": ca_key_type,
+        },
+    )
+    globals()[name] = cls
 
-    num_replicas = 1
-    master_with_dns = True
-    ipa_key_type = "mldsa"
-    ca_key_type = None
 
+_PQC_INSTALL_VARIANTS = (
+    # IPA keys are ML-DSA, CA keys are RSA (default)
+    (
+        "TestInstallPQCIPACerts",
+        "Install with ML-DSA for IPA service keys (default size).",
+        "mldsa",
+        None,
+    ),
+    (
+        "TestInstallPQCIPACertsMLDSA65",
+        "Install with ML-DSA-65 for IPA service keys.",
+        "mldsa:65",
+        None,
+    ),
+    (
+        "TestInstallPQCIPACertsMLDSA87",
+        "Install with ML-DSA-87 for IPA service keys.",
+        "mldsa:87",
+        None,
+    ),
+    # CA keys are ML-DSA, IPA keys are ML-DSA-44/65/87
+    (
+        "TestInstallPQCCACerts",
+        "Install with ML-DSA CA (default size) and ML-DSA-44 IPA keys.",
+        "mldsa:44",
+        "mldsa",
+    ),
+    (
+        "TestInstallPQCCACertsMLDSA65",
+        "Install with ML-DSA-65 for both IPA keys and CA keys.",
+        "mldsa:65",
+        "mldsa:65",
+    ),
+    (
+        "TestInstallPQCCACertsMLDSA87",
+        "Install with ML-DSA-87 for both IPA keys and CA keys.",
+        "mldsa:87",
+        "mldsa:87",
+    ),
+)
 
-class TestInstallPQCCACerts(TestInstallPQCBase):
+for _name, _doc, _ipa, _ca in _PQC_INSTALL_VARIANTS:
+    _make_pqc_install_class(
+        _name, ipa_key_type=_ipa, ca_key_type=_ca, doc=_doc
+    )
 
-    num_replicas = 1
-    master_with_dns = True
-    ipa_key_type = "mldsa:44"
-    ca_key_type = "mldsa"
+del _name, _doc, _ipa, _ca

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -10,7 +10,9 @@ installed.
 from __future__ import absolute_import
 
 import os
+import random
 import re
+import string
 import textwrap
 import time
 from datetime import datetime, timedelta
@@ -2272,7 +2274,9 @@ class TestInstallKeySizes(IntegrationTest):
         self.check_key_sizes(self.replicas[0])
 
 
-class TestInstallPQCBase(IntegrationTest):
+class PQCInstallBase(IntegrationTest):
+    num_replicas = 0
+    master_with_dns = True
     ipa_key_type = None
     ca_key_type = None
 
@@ -2285,8 +2289,10 @@ class TestInstallPQCBase(IntegrationTest):
             extra_args.extend(["--ca-key-type", cls.ca_key_type])
         tasks.install_master(cls.master, setup_dns=True,
                              extra_args=extra_args)
-        tasks.install_replica(
-            cls.master, cls.replicas[0], setup_ca=True)
+        # Only install replica if configured
+        if cls.num_replicas > 0:
+            tasks.install_replica(
+                cls.master, cls.replicas[0], setup_ca=True)
 
     def _get_key_type(self, type):
         if type:
@@ -2330,7 +2336,7 @@ class TestInstallPQCBase(IntegrationTest):
         assert "2048 bit" in result.stdout_text
 
     def check_ca_keys(self, host):
-        """Verify that the CA keys are all RSA"""
+        """Verify Dogtag CA signing keys match the configured CA key type."""
         key_type = self._get_key_type(self.ca_key_type)
         if "ML-DSA-" in key_type:
             key_type = "mldsa"
@@ -2338,7 +2344,9 @@ class TestInstallPQCBase(IntegrationTest):
         result = host.run_command(
             f"certutil -K -d {paths.PKI_TOMCAT_ALIAS_DIR} "
             f"-f {paths.PKI_TOMCAT_ALIAS_PWDFILE_TXT} | grep -c {key_type}")
-        assert "5" in result.stdout_text
+        # Dogtag CA should have exactly 5 signing keys of the expected type
+        key_count = int(result.stdout_text.strip())
+        assert key_count == 5, f"Expected 5 CA keys, found {key_count}"
 
     def test_master_key_sizes(self):
         self.check_key_sizes(self.master)
@@ -2355,8 +2363,101 @@ class TestInstallPQCBase(IntegrationTest):
         self.check_key_sizes(self.replicas[0])
         self.check_ca_keys(self.replicas[0])
 
+    def test_replica_ca_issues_cert_with_mldsa(self):
+        """Test that replica CA can issue certificates with ML-DSA config.
 
-class TestInstallPQCIPACerts(TestInstallPQCBase):
+        Validates:
+        - Replica CA is functional and certificates issue works with replica
+        - Certificate matches configured key type
+        - Signature algorithm matches CA type for ML-DSA scenarios
+        - CA replication works correctly for ML-DSA scenarios
+        """
+        if self.num_replicas == 0:
+            raise pytest.skip("No replica installed. Skipping")
+        result = tasks.kinit_admin(self.replicas[0], raiseonerr=False)
+        if result.returncode != 0:
+            raise pytest.skip("Replica is not available. Skipping")
+
+        replica = self.replicas[0]
+        expected_key_type = self._get_key_type(self.ipa_key_type)
+
+        # Create a test user with random suffix to avoid collisions on reruns
+        suffix = ''.join(
+            random.choices(string.ascii_lowercase + string.digits, k=8))
+        test_user = f"pqctest{suffix}"
+
+        # Define file paths before try block to ensure cleanup scope
+        csr_file = os.path.join(paths.OPENSSL_DIR,
+                                f"replica_test_{suffix}.csr")
+        key_file = os.path.join(paths.OPENSSL_PRIVATE_DIR,
+                                f"replica_test_{suffix}.key")
+        cert_file = os.path.join(paths.OPENSSL_CERTS_DIR,
+                                 f"replica_test_{suffix}.crt")
+
+        tasks.kinit_admin(replica)
+        try:
+            tasks.user_add(replica, test_user)
+
+            # Generate key and CSR based on configured IPA key type
+            if self.ipa_key_type and self.ipa_key_type.startswith("mldsa"):
+                # ML-DSA CSR
+                algo = expected_key_type
+                replica.run_command([
+                    "openssl", "genpkey", "-algorithm", algo,
+                    "-out", key_file
+                ])
+                replica.run_command([
+                    "openssl", "req", "-new", "-key", key_file,
+                    "-out", csr_file, "-subj", f"/CN={test_user}"
+                ])
+            else:
+                # RSA CSR (default)
+                replica.run_command([
+                    "openssl", "req", "-newkey", "rsa:2048",
+                    "-keyout", key_file, "-nodes", "-out", csr_file,
+                    "-subj", f"/CN={test_user}"
+                ])
+
+            # Request certificate from replica CA
+            replica.run_command([
+                "ipa", "cert-request", "--principal", test_user,
+                "--certificate-out", cert_file, csr_file
+            ])
+
+            # Validate issued certificate has expected public key type
+            pk_result = replica.run_command(
+                f"openssl x509 -in {cert_file} -noout -text | grep Public-Key"
+            )
+            assert expected_key_type in pk_result.stdout_text, (
+                f"Expected {expected_key_type} in certificate, "
+                f"got: {pk_result.stdout_text}"
+            )
+
+            # For ML-DSA CA, also verify Signature Algorithm
+            if self.ca_key_type and self.ca_key_type.startswith("mldsa"):
+                sig_result = replica.run_command(
+                    f"openssl x509 -in {cert_file} -noout -text | "
+                    "grep 'Signature Algorithm'"
+                )
+                assert "ml-dsa" in sig_result.stdout_text.lower(), (
+                    f"Expected ML-DSA signature algorithm, "
+                    f"got: {sig_result.stdout_text}"
+                )
+
+        finally:
+            # Cleanup
+            replica.run_command(
+                ["rm", "-f", csr_file, key_file, cert_file],
+                raiseonerr=False
+            )
+            replica.run_command(
+                ["ipa", "user-del", test_user],
+                raiseonerr=False
+            )
+            tasks.kdestroy_all(replica)
+
+
+class TestInstallPQCIPACerts(PQCInstallBase):
 
     num_replicas = 1
     master_with_dns = True
@@ -2364,9 +2465,42 @@ class TestInstallPQCIPACerts(TestInstallPQCBase):
     ca_key_type = None
 
 
-class TestInstallPQCCACerts(TestInstallPQCBase):
+class TestInstallPQCCACerts(PQCInstallBase):
+    """ML-DSA server keys with ML-DSA-44 CA.
+
+    Configuration:
+        ipa_key_type: 'mldsa' (default ML-DSA-65 for IPA service keys)
+        ca_key_type: 'mldsa:44' (ML-DSA-44 for CA signing keys)
+    """
+
+    num_replicas = 1
+    master_with_dns = True
+    ipa_key_type = "mldsa"
+    ca_key_type = "mldsa:44"
+
+
+class TestInstallWithMLDSA44(PQCInstallBase):
+    """Install with ML-DSA-44 for both IPA service keys and CA."""
 
     num_replicas = 1
     master_with_dns = True
     ipa_key_type = "mldsa:44"
-    ca_key_type = "mldsa"
+    ca_key_type = "mldsa:44"
+
+
+class TestInstallWithMLDSA65(PQCInstallBase):
+    """Install with ML-DSA-65 for both IPA service keys and CA."""
+
+    num_replicas = 1
+    master_with_dns = True
+    ipa_key_type = "mldsa:65"
+    ca_key_type = "mldsa:65"
+
+
+class TestInstallWithMLDSA87(PQCInstallBase):
+    """Install with ML-DSA-87 for both IPA service keys and CA."""
+
+    num_replicas = 1
+    master_with_dns = True
+    ipa_key_type = "mldsa:87"
+    ca_key_type = "mldsa:87"


### PR DESCRIPTION
Enhance PQC/ML-DSA Certificate Integration Test Coverage
This PR significantly expands the integration test suite for Post-Quantum Cryptography (PQC) and ML-DSA certificates within FreeIPA. The primary goal is to ensure robust validation of ML-DSA CA behavior, master/client certificate issuance, and certificate enrollment processes, including new tests for replica CA functionality.
## Integration Tests Coverage
The existing test coverage, now updated and expanded, includes:
### 1. ML-DSA CA Behavior (`TestInstallMasterClientMLDSACA`)
This test class validates the core functionality of an ML-DSA enabled Certificate Authority.
- ✅ `test_ca_signing_keys_are_mldsa` - Verifies that the CA correctly uses ML-DSA signing keys.
- ✅ `test_user_cert_rsa_csr_signed_by_mldsa_ca` - Ensures RSA user certificates can be signed by an ML-DSA CA.
- ✅ `test_user_cert_mldsa_csr_signed_by_mldsa_ca` - Validates ML-DSA user certificates issued by an ML-DSA CA.
- ✅ `test_getcert_mldsa_key_signed_by_mldsa_ca` - Tests master host certificate issuance with ML-DSA keys.
- ✅ `test_getcert_rsa_key_signed_by_mldsa_ca` - Tests master host certificate issuance with RSA keys.
- ✅ `test_getcert_mldsa_key_client_signed_by_mldsa_ca` - Validates client host certificate issuance with ML-DSA keys.
- Inherited Tests: Plus 9 inherited tests from `TestInstallMasterClient` covering certificate tracking, profile validation, SAN handling, and SubCA scenarios.
### 2. Master/Client Certificates (`TestInstallMasterClientMLDSA`)
This class focuses on the issuance of master and client certificates with ML-DSA keys against an RSA CA.
- ✅ `test_user_cert_mldsa_csr_signed_by_rsa_ca` - Verifies user certificate requests with ML-DSA are signed by an RSA CA.
- ✅ `test_getcert_mldsa_key_signed_by_rsa_ca` - Ensures host certificate requests with ML-DSA are signed by an RSA CA.
- Inherited Tests: Plus 9 inherited tests from `TestInstallMasterClient`.
### 3. Enrollment Tests (Master + Replica)
These tests cover the certificate enrollment process on both master and replica servers.
- `TestPQCCertEnrollmentIPACerts` (ML-DSA IPA + RSA CA)
- `TestPQCCertEnrollmentCACerts` (ML-DSA IPA + ML-DSA CA)
- ✅ `test_getcert_enroll_caIPAserviceCert_mldsa_key_master` - Validates Certmonger enrollment on the master.
- ✅ `test_getcert_enroll_caIPAserviceCert_mldsa_key_replica` - Validates Certmonger enrollment on the replica.
- ✅ `test_ipa_cert_request_mldsa_caIPAservice_profile_master` - Tests direct `ipa cert-request` on the master.
## New Additions: Replica CA Functionality Test
A significant addition in this PR is the new test case:
- `test_replica_ca_issues_cert_with_mldsa()` in `TestInstallPQCBase`.
This test specifically validates:
1.  **Replica CA Issuance**: Confirms that a replica CA can successfully issue certificates, ensuring CA replication is functional.
2.  **ML-DSA Key Type Validation**: Verifies that certificates issued from the replica possess the correct ML-DSA key type.
3.  **Full Workflow**: Covers the end-to-end process from user creation, CSR generation, certificate request, to final certificate validation.
**Commands Executed within the test:**
```bash
# On replica:
ipa user-add pqc_replica_test_user
openssl genpkey -algorithm ML-DSA-65 -out /tmp/replica_test.key
openssl req -new -key /tmp/replica_test.key -out /tmp/replica_test.csr
ipa cert-request --principal pqc_replica_test_user /tmp/replica_test.csr
openssl x509 -in /tmp/replica_test.crt -noout -text | grep Public-Key


**Tests are executed in Jenkins on fedora-rawhide. with copr enabled : shalini10/freeipa.** 
Metadata ; Working pipeline results : 
https://{gitlab}/-/snippets/12236
https://{ARTIFACE_SERVER}/idm-ci/idm-ci/trigger/prod/trigger/run/null/16024/report.html?sort=result
https://{gitlab}/-/snippets/12233
https://{ARTIFACE_SERVER}/idm-ci/idm-ci/trigger/prod/trigger/run/null/16020/report.html?sort=result

## Summary by Sourcery

Expand FreeIPA’s PQC integration coverage to validate ML-DSA certificate installation, issuance, and enrollment across supported CA and topology configurations.

New Features:
- Add integration coverage for ML-DSA certificate issuance with RSA and ML-DSA CSRs, service certificates, and CA configurations.
- Validate ML-DSA certificate enrollment on masters and replicas, including replica CA issuance.

Enhancements:
- Refactor PQC installation helpers to support optional replicas and validate configured CA key types.

CI:
- Run dedicated PQC integration suites on Fedora Rawhide with master, replica, and client topologies.

Tests:
- Add ML-DSA certificate integration tests covering CA keys, certificate public keys, certmonger enrollment, SAN handling, and multiple ML-DSA parameter sets.