### PR TITLE
[Backport][ipa-4-13] prci definitions: increase test_sudo timeout

### DIFF
--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -140,7 +140,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
         test_suite: test_integration/test_sudo.py
         template: *ci-ipa-4-13-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-13/test_commands:

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
@@ -132,7 +132,7 @@ jobs:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
         test_suite: test_integration/test_sudo.py
         template: *ci-ipa-4-13-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-13/test_commands:

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
@@ -138,7 +138,7 @@ jobs:
         selinux_enforcing: True
         test_suite: test_integration/test_sudo.py
         template: *ci-ipa-4-13-latest
-        timeout: 4800
+        timeout: 5400
         topology: *master_1repl_1client
 
   fedora-latest-ipa-4-13/test_commands:


### PR DESCRIPTION
The test takes slightly more than 4800s (1h20). Increase the timeout to 5400s (1h30)

Backported and adapted from https://github.com/freeipa/freeipa/commit/5e033abebcbd9f0d4db3a0520efdd8568251d968

which was part of https://github.com/freeipa/freeipa/pull/8402

## Summary by Sourcery

CI:
- Raise the timeout for test_integration/test_sudo.py from 4800s to 5400s in gating and nightly ipa-4-13 Fedora latest CI definitions, including SELinux enforcing runs.