### PR TITLE
[Backport][ipa-4-11] Fix naive Referer check bypass in rpcserver

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -32,7 +32,7 @@ import time
 import traceback
 from io import BytesIO
 from sys import version_info
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlparse
 from xmlrpc.client import Fault
 
 import gssapi
@@ -160,13 +160,38 @@ class HTTP_Status(plugable.Plugin):
         if "HTTP_REFERER" not in environ:
             logger.error("Rejecting request with missing Referer")
             return False
-        if (not environ["HTTP_REFERER"].startswith(
-                "https://%s/ipa" % self.api.env.host)
-                and not self.env.in_tree):
-            logger.error("Rejecting request with bad Referer %s",
-                         environ["HTTP_REFERER"])
+
+        if self.env.in_tree:
+            return True
+
+        referer = environ["HTTP_REFERER"]
+
+        if referer.count("://") > 1:
+            logger.error(
+                "Rejecting request with multiple Referer values %s",
+                referer,
+            )
             return False
-        logger.debug("Valid Referer %s", environ["HTTP_REFERER"])
+
+        try:
+            parsed = urlparse(referer)
+        except Exception as e:
+            logger.error(
+                "Rejecting request with unparseable Referer %s: %s", referer, e
+            )
+            return False
+
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != self.api.env.host
+            or (parsed.path != "/ipa" and not parsed.path.startswith("/ipa/"))
+        ):
+            logger.error(
+                "Rejecting request with bad Referer %s", referer
+            )
+            return False
+
+        logger.debug("Valid Referer %s", referer)
         return True
 
     def not_found(self, environ, start_response, url, message):


### PR DESCRIPTION
This PR was opened automatically because PR #8324 was pushed to master and backport to ipa-4-11 is required.

## Summary by Sourcery

Harden Referer validation in the RPC server and enforce the check on incoming requests to prevent bypasses.

Bug Fixes:
- Reject RPC requests with malformed, multiple, or invalid Referer headers instead of allowing them through due to naive prefix checks.
- Return an HTTP bad request response when the Referer validation fails before further request processing.