### PR TITLE
 Revert sync_token referer check

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -1309,9 +1309,6 @@ class sync_token(Backend, HTTP_Status):
         self.api.Backend.wsgi_dispatch.mount(self, self.key)
 
     def __call__(self, environ, start_response):
-        if not self.check_referer(environ):
-            return self.bad_request(environ, start_response, 'denied')
-
         # Make sure this is a form request.
         content_type = environ.get('CONTENT_TYPE', '').lower()
         if not content_type.startswith('application/x-www-form-urlencoded'):


### PR DESCRIPTION
The check here can't be used, we would have to either add referer to the
request, as the request is made through ipa tool, but that is misleading
referer is commonly a web browser thing.

Fixes: https://pagure.io/freeipa/issue/10001

## Summary by Sourcery

Remove the HTTP Referer check from the RPC server sync token handling and update the temporary CI integration job configuration accordingly.

Bug Fixes:
- Allow sync token requests to proceed without enforcing an HTTP Referer check in the RPC server.

Tests:
- Retarget the temporary CI integration job to run the OTP integration test suite with a single-replica topology.