### PR TITLE
freeipa.spec: bump samba version

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -70,7 +70,7 @@
 %global krb5_kdb_version 9.0
 # 0.7.16: https://github.com/drkjam/netaddr/issues/71
 %global python_netaddr_version 0.7.19
-%global samba_version 4.17.4-101
+%global samba_version 4.24.3-1
 %global slapi_nis_version 0.56.4
 %global python_ldap_version 3.1.0-1
 # version supporting Allow Uniqueness plugin to search uniqueness attributes
@@ -103,16 +103,10 @@
 %global python_netaddr_version 0.7.16
 # Require 4.7.0 which brings Python 3 bindings
 # Require 4.12 which has DsRGetForestTrustInformation access rights fixes
-%if 0%{?fedora} <= 40
-%global samba_version 2:4.12.10
-%elif 0%{?fedora} == 41
-# Require 4.20.0 or later for libndr4, latest F41 is 4.21.7 already
-%global samba_version 2:4.21.7
-%elif 0%{?fedora} == 42
-%global samba_version 2:4.22.0
+%if 0%{?fedora} < 44
+%global samba_version 2:4.23.8
 %else
-# Require 4.23 for passdb ABI bump
-%global samba_version 2:4.23.0
+%global samba_version 2:4.24.3
 %endif
 
 # 3.14.5-45 or later includes a number of interfaces fixes for IPA interface


### PR DESCRIPTION
Samba 4.23-8 is available on fedora 43 and 4.24.3 on fedora 44.
On RHEL 9.9 and 10.3 we will have 4.24.3.

## Summary by Sourcery

Update Fedora CI pipelines to run Active Directory trust integration tests on both current and previous Fedora baselines and align PR CI config with new test definition.

CI:
- Replace the Fedora latest temp_commit job with a trust integration test job using the AD trust topology.
- Add Fedora previous build and trust test jobs targeting the Fedora 43 CI template and AD trust topology.
- Point the PR CI configuration to the updated PRCI definition file.