### PR TITLE
[Backport][ipa-4-9]  Revert sync_token referer check

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -1303,9 +1303,6 @@ class sync_token(Backend, HTTP_Status):
         self.api.Backend.wsgi_dispatch.mount(self, self.key)
 
     def __call__(self, environ, start_response):
-        if not self.check_referer(environ):
-            return self.bad_request(environ, start_response, 'denied')
-
         # Make sure this is a form request.
         content_type = environ.get('CONTENT_TYPE', '').lower()
         if not content_type.startswith('application/x-www-form-urlencoded'):


### PR DESCRIPTION
This PR was opened automatically because PR #8437 was pushed to master and backport to ipa-4-9 is required.

## Summary by Sourcery

Bug Fixes:
- Restore compatibility for sync token RPC requests by removing the restrictive HTTP Referer validation introduced previously.