### PR TITLE
Convert Pagure links to Codeberg

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -5,9 +5,9 @@ Explanation
 # Explanation must describe the fix or feature + the method
 # chosen to implement it, and can span across multiple lines.
 
-Fixes: https://pagure.io/freeipa/issue/XXXX
+Fixes: https://codeberg.org/freeipa/freeipa/issues/XXXX
 or
-Related: https://pagure.io/freeipa/issue/XXXX
+Related: https://codeberg.org/freeipa/freeipa/issues/XXXX
 # Fixes: means that the commit fixes the referenced issue(s).
 # Related: means that the commit is related to the issue(s)
 # in some way, but does not resolve it/them.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ tools for the following components:
 * PKI based on [Dogtag project](http://pki.fedoraproject.org/wiki/PKI_Main_Page)
 * [Samba](http://www.samba.org/) libraries for Active Directory integration
 * DNS Server based on [BIND](https://www.isc.org/software/bind) and the
-  [Bind-DynDB-LDAP plugin](https://pagure.io/bind-dyndb-ldap)
+  [Bind-DynDB-LDAP plugin](https://codeberg.org/freeipa/bind-dyndb-ldap)
 
 ## Project Website
 
@@ -72,7 +72,7 @@ Please see the file called COPYING.
   subscribe to the freeipa-announce mailing list at
   https://www.redhat.com/mailman/listinfo/freeipa-interest/ .
 * If you have a bug report please submit it at:
-  https://pagure.io/freeipa/issues
+  https://codeberg.org/freeipa/freeipa/issues
 * If you want to participate in actively developing IPA please
   subscribe to the freeipa-devel mailing list at
   https://lists.fedoraproject.org/archives/list/freeipa-devel@lists.fedorahosted.org/ or join

--- a/client/ipa-getkeytab.c
+++ b/client/ipa-getkeytab.c
@@ -880,7 +880,7 @@ static int resolve_ktname(const char *keytab, char **ktname, char **err_msg)
 	*err_msg = NULL;
 
     /* Resolve keytab symlink to support dangling symlinks, see
-     * https://pagure.io/freeipa/issue/4607. To prevent symlink attacks,
+     * https://codeberg.org/freeipa/freeipa/issues/4607. To prevent symlink attacks,
      * the symlink is only resolved owned by the current user or by
      * root. For simplicity, only one level if indirection is resolved.
      */

--- a/client/man/ipa-epn.1
+++ b/client/man/ipa-epn.1
@@ -136,7 +136,7 @@ If the \fBLANG\fR environment variable is set, and the template contains a datet
 The exit status is 0 on success, nonzero on error.
 
 .SH "SEE ALSO"
-   RFE: https://pagure.io/freeipa/issue/3687
+   RFE: https://codeberg.org/freeipa/freeipa/issues/3687
    Design document: https://github.com/freeipa/freeipa/blob/master/doc/designs/expiring-password-notification.md
 
 
@@ -145,5 +145,5 @@ The exit status is 0 on success, nonzero on error.
 
 .SH "REPORTING BUGS AND ENHANCEMENT IDEAS"
 .nf
-   Please make sure first the issue is not already reported by searching at https://pagure.io/freeipa/issues. If it is not, file a new issue at https://pagure.io/freeipa/new_issue.
+   Please make sure first the issue is not already reported by searching at https://codeberg.org/freeipa/freeipa/issues. If it is not, file a new issue at https://codeberg.org/freeipa/freeipa/issues/new.
 

--- a/doc/designs/adtrust/sidconfig.md
+++ b/doc/designs/adtrust/sidconfig.md
@@ -7,7 +7,7 @@ for trust. The goal of this feature is to allow PAC generation in the
 general use case, even without trust, as it is a first step towards
 IPA-IPA trust.
 
-Reference: https://pagure.io/freeipa/issue/8995
+Reference: https://codeberg.org/freeipa/freeipa/issues/8995
 
 In order to generate PAC data for a kerberos principal, IPA needs to assign
 a SID to the users and groups. IPA installers (`ipa-server-install`,

--- a/doc/designs/adtrust/sudorules-with-ad-objects.md
+++ b/doc/designs/adtrust/sudorules-with-ad-objects.md
@@ -110,7 +110,7 @@ attribute.
 
 Note that direct manipulation of `externalUser` attribute through IPA
 parameters is not allowed since 2011 (FreeIPA tickets
-https://pagure.io/freeipa/issue/1320). With membership validation method SUDO
+https://codeberg.org/freeipa/freeipa/issues/1320). With membership validation method SUDO
 rules can now handle those members through the normal `--users` mechanism.
 
 Same approach is used to provide handling of `RunAs_Member` specification

--- a/doc/designs/client-install-pkinit.md
+++ b/doc/designs/client-install-pkinit.md
@@ -2,7 +2,7 @@
 
 This design document proposes PKINIT as an additional authentication
 mechanism for `ipa-client-install`, ticket
-[https://pagure.io/freeipa/issue/9271](https://pagure.io/freeipa/issue/9271).
+[https://codeberg.org/freeipa/freeipa/issues/9271](https://codeberg.org/freeipa/freeipa/issues/9271).
 
 ## Overview
 

--- a/doc/designs/disable-stale-users.md
+++ b/doc/designs/disable-stale-users.md
@@ -9,7 +9,7 @@ amount of time be automatically disabled in the identity management system.
 
 FreeIPA does not keep track of successful authentication events.
 The krbLastSuccessfulAuth attribute is not updated by default since
-https://pagure.io/freeipa/issue/5313 for reliability reasons.
+https://codeberg.org/freeipa/freeipa/issues/5313 for reliability reasons.
 Therefore distinguishing between stale and active accounts cannot be done with
 existing logon data.
 
@@ -38,7 +38,7 @@ For environments where user passwords never expire, a new mechanism must be
 added to FreeIPA plugins ipa-kdb and ipa-lockout to account for each user
 account authentication events. Since updating a LDAP user account attribute on
 each authentication event must be avoided as the update frequency could easily
-be high, (see https://pagure.io/freeipa/issue/5313 for background
+be high, (see https://codeberg.org/freeipa/freeipa/issues/5313 for background
 information), a coarse update mechanism is proposed.
 
 An attribute containing a timestamp is added to each user:

--- a/doc/designs/expiring-password-notification.md
+++ b/doc/designs/expiring-password-notification.md
@@ -5,7 +5,7 @@
 ## Overview
 
 A method to warn users via email that their IPA account password is about to expire.
-Ticket [link](https://pagure.io/freeipa/issue/3687).
+Ticket [link](https://codeberg.org/freeipa/freeipa/issues/3687).
 
 ## User Stories
 
@@ -174,7 +174,7 @@ The documentation should be enhanced:
 * Systemd Timer
 A man page must cover ipa-epn.
 
-The WebUI [notification feature](https://pagure.io/freeipa/issue/3687) (ipapwdexpadvnotify) must be mentioned in the documentation as well.
+The WebUI [notification feature](https://codeberg.org/freeipa/freeipa/issues/3687) (ipapwdexpadvnotify) must be mentioned in the documentation as well.
 
 
 ## Testing

--- a/doc/designs/ldap_pam_passthrough.md
+++ b/doc/designs/ldap_pam_passthrough.md
@@ -175,7 +175,7 @@ ipapwd_pre_bind_otp() return 0 if any authentication indicator is set.
 Additionally, multiple mechanisms should be supported simultaneously
 so a user configured with PKINIT and RADIUS can authenticate using
 either. Currently only RADIUS will work. See 
-https://pagure.io/freeipa/issue/8820 for more details. This should
+https://codeberg.org/freeipa/freeipa/issues/8820 for more details. This should
 also work for an LDAP bind for consistency.
 
 ### The workflow

--- a/doc/designs/ldapi-autobind-services.md
+++ b/doc/designs/ldapi-autobind-services.md
@@ -131,5 +131,5 @@ https://www.port389.org/docs/389ds/FAQ/ldapi-and-autobind.html)
 * [LDAPI autobind DN rewriter](
 https://www.port389.org/docs/389ds/design/ldapi-auto-auth-dn-design.html)
 * 389-DS feature request [GH-4381](https://github.com/389ds/389-ds-base/issues/4381)
-* FreeIPA bug report [pagure-8544](https://pagure.io/freeipa/issue/8544)
+* FreeIPA bug report [pagure-8544](https://codeberg.org/freeipa/freeipa/issues/8544)
   for replication issue due to clock mismatch.

--- a/doc/designs/libpwquality.md
+++ b/doc/designs/libpwquality.md
@@ -5,10 +5,10 @@
 Improved password quality checking using the capabilities of libpwquality.
 
 Tickets:
-    [https://pagure.io/freeipa/issue/6964](https://pagure.io/freeipa/issue/6964)
-    [https://pagure.io/freeipa/issue/5948](https://pagure.io/freeipa/issue/5948)
-    [https://pagure.io/freeipa/issue/2445](https://pagure.io/freeipa/issue/2445)
-    [https://pagure.io/freeipa/issue/298](https://pagure.io/freeipa/issue/298)
+    [https://codeberg.org/freeipa/freeipa/issues/6964](https://codeberg.org/freeipa/freeipa/issues/6964)
+    [https://codeberg.org/freeipa/freeipa/issues/5948](https://codeberg.org/freeipa/freeipa/issues/5948)
+    [https://codeberg.org/freeipa/freeipa/issues/2445](https://codeberg.org/freeipa/freeipa/issues/2445)
+    [https://codeberg.org/freeipa/freeipa/issues/298](https://codeberg.org/freeipa/freeipa/issues/298)
 
 ## User Stories
 

--- a/doc/designs/subordinate-ids.md
+++ b/doc/designs/subordinate-ids.md
@@ -15,7 +15,7 @@ provide them to userspace tools.
 
 Feature requests
 
-* [FreeIPA feature request #8361](https://pagure.io/freeipa/issue/8361)
+* [FreeIPA feature request #8361](https://codeberg.org/freeipa/freeipa/issues/8361)
 * [SSSD feature request #5197](https://github.com/SSSD/sssd/issues/5197)
 * [shadow-util feature request #154](https://github.com/shadow-maint/shadow/issues/154)
 * [389-DS RFE for DNA plugin rhbz#1938239](https://bugzilla.redhat.com/show_bug.cgi?id=1938239)

--- a/doc/designs/template.md
+++ b/doc/designs/template.md
@@ -61,7 +61,7 @@ Any impact on upgrades? Remove this section if not applicable.
 
 ## Test plan
 
-Test scenarios that will be transformed to test cases for FreeIPA [Continuous Integration](https://www.freeipa.org/page/V3/Integration_testing) during implementation or review phase. This can be also link to source in [pagure](https://pagure.io/freeipa.git) with the test, if appropriate. 
+Test scenarios that will be transformed to test cases for FreeIPA [Continuous Integration](https://www.freeipa.org/page/V3/Integration_testing) during implementation or review phase. This can be also link to source in [Codeberg](https://codeberg.org/freeipa/freeipa.git) with the test, if appropriate. 
 
 ## Troubleshooting and debugging
 

--- a/doc/workshop/workshop.rst
+++ b/doc/workshop/workshop.rst
@@ -264,7 +264,7 @@ the workshop is over:
   <https://www.freeipa.org/page/Troubleshooting>`_: how to debug
   common problems; how to report bugs
 
-- `Bug tracker <https://pagure.io/freeipa>`_
+- `Bug tracker <https://codeberg.org/freeipa/freeipa>`_
 
 - Information about the `FreeIPA public demo
   <https://www.freeipa.org/page/Demo>`_ instance

--- a/freeipa.doap.rdf
+++ b/freeipa.doap.rdf
@@ -8,7 +8,7 @@
         <homepage rdf:resource="https://www.freeipa.org" />
         <shortdesc>FreeIPA is the upstream open-source project for Red Hat Identity Manager</shortdesc>
         <description>FreeIPA is an integrated security information management solution combining Linux (Fedora), 389 Directory Server, MIT Kerberos, Chronyd, DNS, Dogtag (Certificate System). It consists of a web interface and command-line administration tools.</description>
-        <bug-database rdf:resource="https://pagure.io/freeipa/" />
+        <bug-database rdf:resource="https://codeberg.org/freeipa/freeipa/" />
         <mailing-list rdf:resource="https://www.freeipa.org/page/Contribute" />
         <mailing-list>freeipa-interest@redhat.com</mailing-list>
         <mailing-list>freeipa-devel@lists.fedorahosted.org</mailing-list>

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -134,7 +134,7 @@
 %global krb5_kdb_version 9.0
 %endif
 
-# fix for segfault in python3-ldap, https://pagure.io/freeipa/issue/7324
+# fix for segfault in python3-ldap, https://codeberg.org/freeipa/freeipa/issues/7324
 %global python_ldap_version 3.1.0-1
 
 # Make sure to use 389-ds-base versions that fix https://github.com/389ds/389-ds-base/issues/6857
@@ -205,14 +205,14 @@
 
 %if 0%{?fedora} >= 33 || 0%{?rhel} >= 9
 # systemd with resolved enabled
-# see https://pagure.io/freeipa/issue/8275
+# see https://codeberg.org/freeipa/freeipa/issues/8275
 %global systemd_version 246.6-3
 %else
 %global systemd_version 239
 %endif
 
 # augeas support for new chrony options
-# see https://pagure.io/freeipa/issue/8676
+# see https://codeberg.org/freeipa/freeipa/issues/8676
 # https://bugzilla.redhat.com/show_bug.cgi?id=1931787
 %if 0%{?fedora} >= 33
 %global augeas_version 1.12.0-6
@@ -250,10 +250,10 @@ Summary:        The Identity, Policy and Audit system
 
 License:        GPL-3.0-or-later
 URL:            http://www.freeipa.org/
-Source0:        https://releases.pagure.org/freeipa/freeipa-%{version}%{?rc_version}.tar.gz
+Source0:        https://codeberg.org/freeipa/freeipa/releases/download/%{version}/freeipa-%{version}%{?rc_version}.tar.gz
 # Only use detached signature for the distribution builds. If it is a developer build, skip it
 %if %{NON_DEVELOPER_BUILD}
-Source1:        https://releases.pagure.org/freeipa/freeipa-%{version}%{?rc_version}.tar.gz.asc
+Source1:        https://codeberg.org/freeipa/freeipa/releases/download/%{version}/freeipa-%{version}%{?rc_version}.tar.gz.asc
 # https://www.freeipa.org/page/Verify_Release_Signature
 #
 # The following commands can be used to fetch the signing key via fingerprint
@@ -330,10 +330,10 @@ BuildRequires:  libsss_idmap-devel
 BuildRequires:  libsss_certmap-devel
 BuildRequires:  libsss_nss_idmap-devel >= %{sssd_version}
 %if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
-# Do not use nodejs22 on fedora < 41, https://pagure.io/freeipa/issue/9643
+# Do not use nodejs22 on fedora < 41, https://codeberg.org/freeipa/freeipa/issues/9643
 BuildRequires: nodejs(abi), /usr/bin/node, /usr/bin/npm
 %elif 0%{?fedora} >= 39
-# Do not use nodejs20 on fedora < 39, https://pagure.io/freeipa/issue/9374
+# Do not use nodejs20 on fedora < 39, https://codeberg.org/freeipa/freeipa/issues/9374
 BuildRequires:  nodejs(abi) < 127, nodejs-npm
 %else
 BuildRequires:  nodejs(abi) < 111, nodejs-npm
@@ -520,7 +520,7 @@ Requires(pre): 389-ds-base >= %{ds_version}
 Requires: font(fontawesome)
 Requires: open-sans-fonts
 %if 0%{?fedora} >= 32 || 0%{?rhel} >= 9
-# https://pagure.io/freeipa/issue/8632
+# https://codeberg.org/freeipa/freeipa/issues/8632
 Requires: openssl > 1.1.1i
 %else
 Requires: openssl
@@ -684,7 +684,7 @@ Requires: bind-dyndb-ldap >= 11.11
 Requires: bind >= %{bind_version}
 Requires: bind-utils >= %{bind_version}
 # bind-dnssec-utils is required by the OpenDNSSec integration
-# https://pagure.io/freeipa/issue/9026
+# https://codeberg.org/freeipa/freeipa/issues/9026
 Requires: bind-dnssec-utils >= %{bind_version}
 %if %{with bind_pkcs11}
 Requires: bind-pkcs11 >= %{bind_version}
@@ -805,7 +805,7 @@ Requires: sssd-tools >= %{sssd_version}
 Requires(post): policycoreutils
 Recommends: %{name}-client-encrypted-dns
 
-# https://pagure.io/freeipa/issue/8530
+# https://codeberg.org/freeipa/freeipa/issues/8530
 Recommends: libsss_sudo
 Recommends: sudo
 Requires: (libsss_sudo if sudo)
@@ -1417,7 +1417,7 @@ if [ $1 -gt 1 ] ; then
             if grep -E -q '^HostKeyAlgorithms ssh-rsa,ssh-dss' $SSH_CLIENT_SYSTEM_CONF 2>/dev/null; then
                 sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"
             fi
-            # https://pagure.io/freeipa/issue/9536
+            # https://codeberg.org/freeipa/freeipa/issues/9536
             # replace sss_ssh_knownhostsproxy with sss_ssh_knownhosts
             if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then
                 if grep -E -q 'Include' $SSH_CLIENT_SYSTEM_CONF  2>/dev/null ; then
@@ -1487,7 +1487,7 @@ test -f '/var/lib/ipa-client/sysrestore/sysrestore.index' && restore=$(wc -l '/v
 if [ -f '/etc/ssh/sshd_config' -a $restore -ge 2 ]; then
     SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
     if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
-        # https://pagure.io/freeipa/issue/9536
+        # https://codeberg.org/freeipa/freeipa/issues/9536
         # downgrade sss_ssh_knownhosts with sss_ssh_knownhostsproxy
         if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then
             if grep -E -q 'Include' $SSH_CLIENT_SYSTEM_CONF  2>/dev/null ; then
@@ -1511,7 +1511,7 @@ test -f '/var/lib/ipa-client/sysrestore/sysrestore.index' && restore=$(wc -l '/v
 if [ -f '/etc/ssh/sshd_config' -a $restore -ge 2 ]; then
     SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
     if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
-        # https://pagure.io/freeipa/issue/9536
+        # https://codeberg.org/freeipa/freeipa/issues/9536
         # upgrade sss_ssh_knownhostsproxy with sss_ssh_knownhosts
         if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then
             if grep -E -q 'Include' $SSH_CLIENT_SYSTEM_CONF  2>/dev/null ; then

--- a/install/ui/src/freeipa/package.json
+++ b/install/ui/src/freeipa/package.json
@@ -34,10 +34,10 @@
     }
   ],
   "license": "GPL-3.0",
-  "bugs": "https://pagure.io/freeipa/issues",
+  "bugs": "https://codeberg.org/freeipa/freeipa/issues",
   "repository": {
     "type": "git",
-    "url": "https://pagure.io/freeipa.git",
+    "url": "https://codeberg.org/freeipa/freeipa.git",
     "path": "install/ui/js/freeipa"
   },
   "devDependencies": {

--- a/install/updates/10-config.update
+++ b/install/updates/10-config.update
@@ -70,6 +70,6 @@ only:nsslapd-ioblocktimeout:10000
 # 389-DS 1.4.1.6+ attempts to update passwords to new schema on LDAP bind.
 # IPa blocks hashed password updates and requires password changes to go
 # through proper APIs. This option disables password hashing schema updates
-# on LDAP bind, see https://pagure.io/freeipa/issue/8315
+# on LDAP bind, see https://codeberg.org/freeipa/freeipa/issues/8315
 dn: cn=config
 only: nsslapd-enable-upgrade-hash:off

--- a/install/updates/10-db-locks.update
+++ b/install/updates/10-db-locks.update
@@ -1,5 +1,5 @@
 # Fix nsslapd-db-locks move
-# https://pagure.io/freeipa/issue/8515
+# https://codeberg.org/freeipa/freeipa/issues/8515
 
 # replace 389-DS default with 50000 locks
 dn: cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config

--- a/install/updates/20-indices.update
+++ b/install/updates/20-indices.update
@@ -45,7 +45,7 @@
 # Update rules
 # ------------
 #
-# - cn uses "only" to avoid bugs like https://pagure.io/freeipa/issue/6975
+# - cn uses "only" to avoid bugs like https://codeberg.org/freeipa/freeipa/issues/6975
 # - nsIndexType and nsMatchingRule use "add" to allow users to add
 #   additional index types and matching rules more easily. The "add" command
 #   adds additional attribute values that are required by IPA but does not

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -385,7 +385,7 @@ CA_TRACKING_REQS = {
 }
 
 # moved from ipaserver/install/krainstance.py::KRAInstance to avoid duplication
-# as per https://pagure.io/freeipa/issue/8795
+# as per https://codeberg.org/freeipa/freeipa/issues/8795
 KRA_TRACKING_REQS = {
     'auditSigningCert cert-pki-kra': 'caAuditSigningCert',
     'transportCert cert-pki-kra': 'caTransportCert',

--- a/ipalib/rpc.py
+++ b/ipalib/rpc.py
@@ -590,7 +590,7 @@ class KerbTransport(SSLTransport):
                     # https://docs.python.org/3/library/http.client.html
                     #   #http.client.HTTPConnection.getresponse
                     #
-                    # https://pagure.io/freeipa/issue/7752
+                    # https://codeberg.org/freeipa/freeipa/issues/7752
                     #
                     response.read()
 

--- a/ipalib/x509.py
+++ b/ipalib/x509.py
@@ -165,7 +165,7 @@ class IPACertificate:
         ext['critical'] = univ.Boolean(critical)
         if pyasn1.__version__.startswith('0.3'):
             # pyasn1 <= 0.3.7 needs explicit encoding
-            # see https://pagure.io/freeipa/issue/7685
+            # see https://codeberg.org/freeipa/freeipa/issues/7685
             value = encoder.encode(univ.OctetString(value))
         ext['extnValue'] = univ.Any(value)
         ext = encoder.encode(ext)
@@ -404,7 +404,7 @@ class IPACertificate:
                 der = ext['extnValue']
                 if pyasn1.__version__.startswith('0.3'):
                     # pyasn1 <= 0.3.7 needs explicit unwrap of ANY container
-                    # see https://pagure.io/freeipa/issue/7685
+                    # see https://codeberg.org/freeipa/freeipa/issues/7685
                     der = decoder.decode(der, asn1Spec=univ.OctetString())[0]
                 gns = decoder.decode(der, asn1Spec=rfc2459.SubjectAltName())[0]
                 break

--- a/ipaplatform/redhat/authconfig.py
+++ b/ipaplatform/redhat/authconfig.py
@@ -167,11 +167,12 @@ class RedHatAuthSelect(RedHatAuthToolBase):
                 'authselect', 'features_list'
             )
             statestore.delete_state('authselect', 'mkhomedir')
-            # https://pagure.io/freeipa/issue/8054
+            # https://codeberg.org/freeipa/freeipa/issues/8054
             if fstore.has_file(paths.NSSWITCH_CONF):
                 logger.info("Restoring user-nsswitch.conf")
                 fstore.restore_file(paths.NSSWITCH_CONF)
-            # only non-empty features, https://pagure.io/freeipa/issue/7776
+            # only non-empty features,
+            # https://codeberg.org/freeipa/freeipa/issues/7776
             if features_state is not None:
                 features = [
                     f.strip() for f in features_state.split(' ') if f.strip()

--- a/ipaplatform/redhat/tasks.py
+++ b/ipaplatform/redhat/tasks.py
@@ -510,7 +510,7 @@ class RedHatTaskNamespace(BaseTaskNamespace):
     def configure_httpd_wsgi_conf(self):
         """Configure WSGI for correct Python version (Fedora)
 
-        See https://pagure.io/freeipa/issue/7394
+        See https://codeberg.org/freeipa/freeipa/issues/7394
         """
         conf = paths.HTTPD_IPA_WSGI_MODULES_CONF
         if sys.version_info.major == 2:

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -579,7 +579,7 @@ class LDAPEntry(MutableMapping):
             else:
                 # dels before adds, in case the same value occurs in
                 # both due to encoding differences
-                # (https://pagure.io/freeipa/issue/7750)
+                # (https://codeberg.org/freeipa/freeipa/issues/7750)
                 if dels:
                     modlist.append((ldap.MOD_DELETE, name, dels))
                 if adds:

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -573,7 +573,7 @@ class CAInstance(DogtagInstance):
         finally:
             if self.external == 1:
                 # Don't remove client DB in external CA step 1
-                # https://pagure.io/freeipa/issue/7742
+                # https://codeberg.org/freeipa/freeipa/issues/7742
                 logger.debug("Keep pkispawn files for step 2")
             else:
                 self.clean_pkispawn_files()

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -185,14 +185,15 @@ class HTTPInstance(service.Service):
         self.update_httpd_service_ipa_conf()
         self.update_httpd_wsgi_conf()
 
-        # create /etc/httpd/alias, see https://pagure.io/freeipa/issue/7529
+        # create /etc/httpd/alias, see
+        # https://codeberg.org/freeipa/freeipa/issues/7529
         session_dir = os.path.dirname(self.sub_dict['GSSAPI_SESSION_KEY'])
         if not os.path.isdir(session_dir):
             os.makedirs(session_dir)
         # Must be world-readable / executable
         os.chmod(session_dir, 0o755)
         # Restore SELinux context of session_dir /etc/httpd/alias, see
-        # https://pagure.io/freeipa/issue/7662
+        # https://codeberg.org/freeipa/freeipa/issues/7662
         tasks.restore_context(session_dir)
 
         target_fname = paths.HTTPD_IPA_CONF

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -521,7 +521,7 @@ class Restore(admintool.AdminTool):
                 # Restart IPA a final time.
                 # Starting then restarting is necessary to make sure some
                 # daemons like httpd are restarted
-                # (https://pagure.io/freeipa/issue/8226).
+                # (https://codeberg.org/freeipa/freeipa/issues/8226).
                 logger.info('Restarting IPA services')
                 result = run([paths.IPACTL, 'restart'], raiseonerr=False)
                 if result.returncode != 0:

--- a/ipaserver/install/kra.py
+++ b/ipaserver/install/kra.py
@@ -178,7 +178,7 @@ def install(api, replica_config, options, custodia):
     # Restart apache for new proxy config file
     services.knownservices.httpd.restart(capture_output=True)
     # Restarted named to restore bind-dyndb-ldap operation, see
-    # https://pagure.io/freeipa/issue/5813
+    # https://codeberg.org/freeipa/freeipa/issues/5813
     named = services.knownservices.named  # alias for current named
     if named.is_running():
         named.restart(capture_output=True)

--- a/ipaserver/install/plugins/fix_kra_people_entry.py
+++ b/ipaserver/install/plugins/fix_kra_people_entry.py
@@ -21,7 +21,7 @@ class fix_kra_people_entry(Updater):
 
     There was a bug where this was created with an incorrect
     'description' attribute, breaking authentication:
-    https://pagure.io/freeipa/issue/8084.
+    https://codeberg.org/freeipa/freeipa/issues/8084.
 
     """
     def execute(self, **options):

--- a/ipaserver/install/replication.py
+++ b/ipaserver/install/replication.py
@@ -655,7 +655,7 @@ class ReplicationManager:
         When installing multiple replicas in parallel, one replica may
         finalize the values while another is still installing.
 
-        See https://pagure.io/freeipa/issue/7617
+        See https://codeberg.org/freeipa/freeipa/issues/7617
         """
         self._finalize_replica_settings(self.conn)
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -1284,7 +1284,7 @@ def uninstall(installer):
     dsinstance.DsInstance(fstore=fstore).uninstall()
     adtrustinstance.ADTRUSTInstance(fstore).uninstall()
     # realm isn't used, but IPAKEMKeys parses /etc/ipa/default.conf
-    # otherwise, see https://pagure.io/freeipa/issue/7474 .
+    # otherwise, see https://codeberg.org/freeipa/freeipa/issues/7474 .
     custodiainstance.CustodiaInstance(realm='REALM.INVALID').uninstall()
     otpdinstance.OtpdInstance().uninstall()
     tasks.restore_hostname(fstore, sstore)

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -987,7 +987,7 @@ def promote_check(installer):
 
     installutils.verify_fqdn(config.host_name, options.no_host_dns)
     # Inside the container environment master's IP address does not
-    # resolve to its name. See https://pagure.io/freeipa/issue/6210
+    # resolve to its name. See https://codeberg.org/freeipa/freeipa/issues/6210
     container_environment = tasks.detect_container() is not None
     installutils.verify_fqdn(config.master_host_name, options.no_host_dns,
                              local_hostname=not container_environment)

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -1446,7 +1446,7 @@ def fix_permissions():
     In case IPA was installed with restricted umask, some public files and
     directories may not be readable and accessible.
 
-    See https://pagure.io/freeipa/issue/7594
+    See https://codeberg.org/freeipa/freeipa/issues/7594
     """
     candidates = [
         os.path.dirname(paths.GSSAPI_SESSION_KEY),
@@ -1891,7 +1891,7 @@ def upgrade_configuration():
     custodia.upgrade_instance()
 
     # Don't include schema upgrades in restart consideration, see
-    # https://pagure.io/freeipa/issue/9204
+    # https://codeberg.org/freeipa/freeipa/issues/9204
     ca_upgrade_schema(ca)
 
     ca_restart = any([

--- a/ipaserver/plugins/cert.py
+++ b/ipaserver/plugins/cert.py
@@ -1971,7 +1971,7 @@ Search for existing certificates.
         complete = False
 
         # Do not execute the CA sub-search in CA-less deployment.
-        # See https://pagure.io/freeipa/issue/8369.
+        # See https://codeberg.org/freeipa/freeipa/issues/8369.
         searches = [self._cert_search]
         if ca_enabled:
             searches.append(self._ca_search)

--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -673,7 +673,7 @@ class server_del(LDAPDelete):
             # since this will break replication.
             # ldap principal to be cleaned later by topology plugin
             # necessary changes to a topology plugin are tracked
-            # under https://pagure.io/freeipa/issue/7359
+            # under https://codeberg.org/freeipa/freeipa/issues/7359
             if master == self.api.env.host:
                 filter = (
                     '(&(krbprincipalname=*/{}@{})'

--- a/ipaserver/plugins/service.py
+++ b/ipaserver/plugins/service.py
@@ -215,7 +215,7 @@ def validate_auth_indicator(entry):
         return
     # The following services are considered internal IPA services
     # and shouldn't be allowed to have auth indicators.
-    # https://pagure.io/freeipa/issue/8206
+    # https://codeberg.org/freeipa/freeipa/issues/8206
     pkey = api.Object['service'].get_primary_key_from_dn(entry.dn)
     if pkey == str(entry.dn):
         # krbcanonicalname may not be set yet if this is a host entry,
@@ -318,7 +318,7 @@ def check_required_principal(ldap, principal):
     """
     if not principal.is_service:
         # bypass check if principal is not a service principal,
-        # see https://pagure.io/freeipa/issue/7793
+        # see https://codeberg.org/freeipa/freeipa/issues/7793
         return
     try:
         host_is_master(ldap, principal.hostname)

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -124,7 +124,7 @@ def pytest_cmdline_main(config):
     kwargs = dict(
         context=u'cli', in_server=False, fallback=False
     )
-    # FIXME: workaround for https://pagure.io/freeipa/issue/8317
+    # FIXME: workaround for https://codeberg.org/freeipa/freeipa/issues/8317
     kwargs.update(in_tree=True)
     if not os.path.isfile(os.path.expanduser('~/.ipa/default.conf')):
         # dummy domain/host for machines without ~/.ipa/default.conf

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -119,7 +119,7 @@ def prepare_host(host):
 def rpcbind_kadmin_workaround(host):
     """Restart rpcbind in case it blocks 749/TCP, 464/UDP, or 464/TCP
 
-    See https://pagure.io/freeipa/issue/7769
+    See https://codeberg.org/freeipa/freeipa/issues/7769
     See https://bugzilla.redhat.com/show_bug.cgi?id=1592883
     """
     cmd = [
@@ -1125,7 +1125,7 @@ def uninstall_master(host, ignore_topology_disconnect=True,
     assert "Traceback" not in result.stdout_text
 
     # Check that IPA certs have been deleted after uninstall
-    # Related: https://pagure.io/freeipa/issue/8614
+    # Related: https://codeberg.org/freeipa/freeipa/issues/8614
     assert host.run_command(['test', '-f', paths.IPA_CA_CRT],
                             raiseonerr=False).returncode == 1
     assert host.run_command(['test', '-f', paths.IPA_P11_KIT],
@@ -2721,7 +2721,7 @@ def kinit_as_user(host, user, password, krb5_trace=False, raiseonerr=True):
     If krb5_trace, then set KRB5_TRACE=/dev/stdout, SSSD_KRB5_LOCATOR_DEBUG=1
     and collect /var/lib/sss/pubconf/kdcinfo.$REALM
     as this file contains the list of KRB5KDC IPs SSSD uses.
-    https://pagure.io/freeipa/issue/8510
+    https://codeberg.org/freeipa/freeipa/issues/8510
     """
 
     if krb5_trace:

--- a/ipatests/test_cmdline/test_cli.py
+++ b/ipatests/test_cmdline/test_cli.py
@@ -312,7 +312,7 @@ class TestCLIParsing:
 
 
 def test_cli_fsencoding():
-    # https://pagure.io/freeipa/issue/5887
+    # https://codeberg.org/freeipa/freeipa/issues/5887
     env = {
         key: value for key, value in os.environ.items()
         if not key.startswith(('LC_', 'LANG'))

--- a/ipatests/test_cmdline/test_ipagetkeytab.py
+++ b/ipatests/test_cmdline/test_ipagetkeytab.py
@@ -339,7 +339,7 @@ class test_ipagetkeytab(KeytabRetrievalTest):
         )
 
     def test_dangling_symlink(self, test_service):
-        # see https://pagure.io/freeipa/issue/4607
+        # see https://codeberg.org/freeipa/freeipa/issues/4607
         test_service.ensure_exists()
 
         fd, symlink_target = tempfile.mkstemp()

--- a/ipatests/test_integration/test_acme.py
+++ b/ipatests/test_integration/test_acme.py
@@ -357,7 +357,7 @@ class TestACME(CALessBase):
         Verifies that the acmeIPAServerCert profile accepts EC keys
         (nistp384 / secp384r1) end-to-end via certbot standalone HTTP-01.
 
-        related: https://pagure.io/freeipa/issue/9984
+        related: https://codeberg.org/freeipa/freeipa/issues/9984
         """
         self.clients[0].run_command(['systemctl', 'stop', 'httpd'])
         self.clients[0].run_command(
@@ -394,7 +394,7 @@ class TestACME(CALessBase):
         exercising the caIPAserviceCert profile key
         constraint that must accept specified curve.
 
-        related: https://pagure.io/freeipa/issue/9984
+        related: https://codeberg.org/freeipa/freeipa/issues/9984
         """
         service_name = f'testecdsa/{self.master.hostname}'
         csr_file = '/tmp/ecdsa_test.csr'
@@ -623,7 +623,7 @@ class TestACMECALess(IntegrationTest):
         Deployment where one server is deployed as CA-less, when converted
         to CA full, should have ACME enabled by default.
 
-        related: https://pagure.io/freeipa/issue/8524
+        related: https://codeberg.org/freeipa/freeipa/issues/8524
         """
         tasks.kinit_admin(self.master)
         # enable acme on master
@@ -660,7 +660,7 @@ class TestACMECALess(IntegrationTest):
         After converting ca-less replica to ca-full, ACME can be
         enabled or disabled.
 
-        related: https://pagure.io/freeipa/issue/8524
+        related: https://codeberg.org/freeipa/freeipa/issues/8524
         """
         tasks.kinit_admin(self.master)
 
@@ -809,7 +809,7 @@ class TestACMERenew(IntegrationTest):
         This test is to check if ACME certificate renews upon
         reaching expiry
 
-        related: https://pagure.io/freeipa/issue/4751
+        related: https://codeberg.org/freeipa/freeipa/issues/4751
         """
         issue_and_expire_acme_cert(
             self.master, self.clients[0], self.acme_server)

--- a/ipatests/test_integration/test_adtrust_install.py
+++ b/ipatests/test_integration/test_adtrust_install.py
@@ -45,7 +45,7 @@ class TestIpaAdTrustInstall(IntegrationTest):
     def test_samba_config_file(self):
         """Check that ipa-adtrust-install generates sane smb.conf
         This is regression test for issue
-        https://pagure.io/freeipa/issue/6951
+        https://codeberg.org/freeipa/freeipa/issues/6951
         """
         self.master.run_command(
             ['ipa-adtrust-install', '-a', self.master.config.admin_password,
@@ -68,7 +68,8 @@ class TestIpaAdTrustInstall(IntegrationTest):
                 "cat",
                 "/var/lib/sss/pubconf/kdcinfo.%s" % self.master.domain.realm
             ], raiseonerr=False)
-            # Set krb5_trace to True: https://pagure.io/freeipa/issue/8353
+            # Set krb5_trace to True:
+            # https://codeberg.org/freeipa/freeipa/issues/8353
             tasks.create_active_user(
                 self.master, user, passwd, first=user, last=user,
                 krb5_trace=True
@@ -101,7 +102,7 @@ class TestIpaAdTrustInstall(IntegrationTest):
         The tool must detect that the replica is stopped and warn that
         a part of the configuration failed.
 
-        Test for https://pagure.io/freeipa/issue/8148
+        Test for https://codeberg.org/freeipa/freeipa/issues/8148
         """
         self.unconfigure_replica_as_agent(self.replicas[0])
         self.replicas[0].run_command(['ipactl', 'stop'])
@@ -244,7 +245,7 @@ class TestIpaAdTrustInstall(IntegrationTest):
 
         This is to ensure if said entry is set after installation with AD.
 
-        related: https://pagure.io/freeipa/issue/8193
+        related: https://codeberg.org/freeipa/freeipa/issues/8193
         """
         conn = self.replicas[0].ldap_connect()
         entry = conn.get_entry(DN(
@@ -605,7 +606,7 @@ class TestIpaAdTrustInstall(IntegrationTest):
         """
         Test checks that samba credential cache is removed after
         ipa-server is uninstalled.
-        https://pagure.io/freeipa/issue/3479
+        https://codeberg.org/freeipa/freeipa/issues/3479
         """
         self.master.run_command(
             ["ipa-adtrust-install", "-a",
@@ -678,7 +679,7 @@ class TestIpaAdTrustInstall(IntegrationTest):
         """
         Test checks that ipa-adtrust-install works fine even
         without smbpasswd file
-        https://pagure.io/freeipa/issue/3181
+        https://codeberg.org/freeipa/freeipa/issues/3181
         """
         error_msg = (
             "< type 'file' > was not found on this system "
@@ -750,7 +751,7 @@ class TestIpaAdTrustInstall(IntegrationTest):
         Test checks that ipa-adtrust-install doesn't fail
         with 'Syntax Error' when dns_lookup_kdc is set to False
         in /etc/krb5.conf
-        https://pagure.io/freeipa/issue/3132
+        https://codeberg.org/freeipa/freeipa/issues/3132
         """
         error_msg = (
             'The ipa-adtrust-install command failed, exception: '
@@ -839,7 +840,7 @@ class TestIpaAdTrustInstall(IntegrationTest):
         """
         This testcase checks that cldap responder doesnot hang
         for domain discovery.
-        https://pagure.io/freeipa/issue/3639
+        https://codeberg.org/freeipa/freeipa/issues/3639
         """
         version = tasks.get_openldap_client_version(self.master)
         if parse_version(version) >= parse_version('2.6'):
@@ -869,7 +870,7 @@ class TestIpaAdTrustInstall(IntegrationTest):
         members of the "admins" group
         Access the share as admin, should work
 
-        https://pagure.io/freeipa/issue/4234
+        https://codeberg.org/freeipa/freeipa/issues/4234
         """
         msg = "tree connect failed: NT_STATUS_ACCESS_DENIED"
         self.master.run_command(

--- a/ipatests/test_integration/test_advise.py
+++ b/ipatests/test_integration/test_advise.py
@@ -194,7 +194,7 @@ class TestAdvice(IntegrationTest):
 
         The command should not fail with error in command.
 
-        Related: https://pagure.io/freeipa/issue/6044
+        Related: https://codeberg.org/freeipa/freeipa/issues/6044
         """
         test = self.master.run_command(["ipa-advise"], raiseonerr=False)
         error = "object of type 'type' has no len()"

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -112,14 +112,14 @@ def check_kinit(host):
 
 
 def check_custodia_files(host):
-    """regression test for https://pagure.io/freeipa/issue/7247"""
+    """regression test for https://codeberg.org/freeipa/freeipa/issues/7247"""
     assert host.transport.file_exists(paths.IPA_CUSTODIA_KEYS)
     assert host.transport.file_exists(paths.IPA_CUSTODIA_CONF)
     return True
 
 
 def check_pkcs11_modules(host):
-    """regression test for https://pagure.io/freeipa/issue/8073"""
+    """regression test for https://codeberg.org/freeipa/freeipa/issues/8073"""
     # Return a dictionary with key = filename, value = file content
     # containing all the PKCS11 modules modified by the installer
     result = dict()
@@ -203,7 +203,7 @@ class TestBackupAndRestore(IntegrationTest):
 
             # check the file permssion and ownership is set to 770 and
             # dirsrv:dirsrv after restore on /var/log/dirsrv/slapd-<instance>
-            # related ticket : https://pagure.io/freeipa/issue/7725
+            # related ticket : https://codeberg.org/freeipa/freeipa/issues/7725
             instance = realm_to_serverid(self.master.domain.realm)
             log_path = paths.VAR_LOG_DIRSRV_INSTANCE_TEMPLATE % instance
             cmd = self.master.run_command(['stat', '-c',
@@ -316,7 +316,7 @@ class BaseBackupAndRestoreWithDNS(IntegrationTest):
     def _full_backup_restore_with_DNS_zone(self, reinstall=False):
         """backup, uninstall, restore.
 
-        Test for bug https://pagure.io/freeipa/issue/7630.
+        Test for bug https://codeberg.org/freeipa/freeipa/issues/7630.
         """
         with restore_checker(self.master):
             self.master.run_command([
@@ -545,7 +545,7 @@ class TestBackupReinstallRestoreWithKRA(BaseBackupAndRestoreWithKRA):
         uninstalled. This test check that there is no error message in
         uninstall log for kra instance.
 
-        related: https://pagure.io/freeipa/issue/8550
+        related: https://codeberg.org/freeipa/freeipa/issues/8550
         """
         cmd = self.master.run_command(['ipa-server-install',
                                        '--uninstall',
@@ -556,10 +556,10 @@ class TestBackupReinstallRestoreWithKRA(BaseBackupAndRestoreWithKRA):
 class TestBackupAndRestoreWithReplica(IntegrationTest):
     """Regression tests for issues 7234 and 7455
 
-    https://pagure.io/freeipa/issue/7234
+    https://codeberg.org/freeipa/freeipa/issues/7234
         - check that oddjobd service is started after restore
         - check new replica  setup after restore
-    https://pagure.io/freeipa/issue/7455
+    https://codeberg.org/freeipa/freeipa/issues/7455
         check that after restore and replication reinitialization
             - users and CA data are at state before backup
             - CA can be installed on existing replica
@@ -744,12 +744,12 @@ class TestUserRootFilesOwnershipPermission(IntegrationTest):
     This test check if files are owned by dirsrv and db2ldif doesn't
     fail
 
-    related ticket: https://pagure.io/freeipa/issue/7010
+    related ticket: https://codeberg.org/freeipa/freeipa/issues/7010
 
     This test also checks if the access rights for user/group
     are set and umask 0022 set while restoring.
 
-    related ticket: https://pagure.io/freeipa/issue/6844
+    related ticket: https://codeberg.org/freeipa/freeipa/issues/6844
     """
 
     @classmethod
@@ -860,7 +860,7 @@ class TestReplicaInstallAfterRestore(IntegrationTest):
     tool which was not backing up the /etc/ipa/custodia/custodia.conf and
     /etc/ipa/custodia/server.keys.
 
-    related ticket: https://pagure.io/freeipa/issue/7247
+    related ticket: https://codeberg.org/freeipa/freeipa/issues/7247
     """
 
     num_replicas = 2
@@ -932,7 +932,7 @@ class TestBackupAndRestoreTrust(IntegrationTest):
     def test_restore_trust_pkg_before_restore(self):
         """Test restore with adtrust when trust-ad pkg is missing.
 
-        Test for bug https://pagure.io/freeipa/issue/7630.
+        Test for bug https://codeberg.org/freeipa/freeipa/issues/7630.
         """
         tasks.install_packages(self.master, ['*ipa-server-trust-ad'])
         self.master.run_command(['ipa-adtrust-install', '-U',
@@ -966,7 +966,7 @@ class TestBackupAndRestoreTrust(IntegrationTest):
 
 class TestBackupRoles(IntegrationTest):
     """ipa-backup should only run on replicas with all the in-use roles
-    https://pagure.io/freeipa/issue/8217
+    https://codeberg.org/freeipa/freeipa/issues/8217
     """
 
     num_replicas = 1

--- a/ipatests/test_integration/test_ca_custom_sdn.py
+++ b/ipatests/test_integration/test_ca_custom_sdn.py
@@ -19,10 +19,10 @@ class TestCACustomSubjectDN(IntegrationTest):
     Generating a random DN might be interest, but for now we construct one
     that regression tests some previously encountered issues:
 
-    * Comma in RDN value: https://pagure.io/freeipa/issue/7347
+    * Comma in RDN value: https://codeberg.org/freeipa/freeipa/issues/7347
 
     * KRA authentication failed for all custom subject DNs:
-      https://pagure.io/freeipa/issue/8084
+      https://codeberg.org/freeipa/freeipa/issues/8084
 
     """
 
@@ -32,7 +32,7 @@ class TestCACustomSubjectDN(IntegrationTest):
     def install(cls, mh):
         """
         Successful installation is sufficient to verify
-        https://pagure.io/freeipa/issue/7347.
+        https://codeberg.org/freeipa/freeipa/issues/7347.
 
         """
         tasks.install_master(
@@ -47,7 +47,7 @@ class TestCACustomSubjectDN(IntegrationTest):
     def test_kra_authn(self):
         """
         vault-add is sufficient to verify
-        https://pagure.io/freeipa/issue/8084.
+        https://codeberg.org/freeipa/freeipa/issues/8084.
 
         """
         self.master.run_command([

--- a/ipatests/test_integration/test_caless.py
+++ b/ipatests/test_integration/test_caless.py
@@ -1148,7 +1148,7 @@ class TestReplicaInstall(CALessBase):
 
     @replica_install_teardown
     def test_certs_with_no_password(self):
-        # related to https://pagure.io/freeipa/issue/7274
+        # related to https://codeberg.org/freeipa/freeipa/issues/7274
 
         self.create_pkcs12('ca1/replica', filename='http.p12',
                            password='')
@@ -1163,7 +1163,7 @@ class TestReplicaInstall(CALessBase):
 
     @replica_install_teardown
     def test_certs_with_no_password_interactive(self):
-        # related to https://pagure.io/freeipa/issue/7274
+        # related to https://codeberg.org/freeipa/freeipa/issues/7274
 
         self.create_pkcs12('ca1/replica', filename='http.p12',
                            password='')

--- a/ipatests/test_integration/test_cert.py
+++ b/ipatests/test_integration/test_cert.py
@@ -82,7 +82,7 @@ class TestInstallMasterClient(IntegrationTest):
         specified by -F option. This fix is to check that cacert file
         creates immediately after certificate goes into MONITORING state.
 
-        related: https://pagure.io/freeipa/issue/8105
+        related: https://codeberg.org/freeipa/freeipa/issues/8105
         """
         cmd_arg = [
             "ipa-getcert", "request",
@@ -111,7 +111,7 @@ class TestInstallMasterClient(IntegrationTest):
         This test utilizes the cert request made in previous test.
         (test_cacert_file_appear_with_option_F)
 
-        related: https://pagure.io/freeipa/issue/3299
+        related: https://codeberg.org/freeipa/freeipa/issues/3299
         """
         # check that request is made against /ipa/json so that
         # IPA enforce json data type
@@ -485,7 +485,7 @@ class TestCertmongerInterruption(IntegrationTest):
         that the request was resubmitted and not rely on catching
         the states directly.
 
-        Pagure Issue: https://pagure.io/freeipa/issue/8164
+        Codeberg Issue: https://codeberg.org/freeipa/freeipa/issues/8164
         """
         cmd = ['getcert', 'list', '-f', paths.RA_AGENT_PEM]
         result = self.replicas[0].run_command(cmd)
@@ -594,8 +594,10 @@ class TestCAShowErrorHandling(IntegrationTest):
         # The regression was introduced in 11.5 and fixed in 11.7
         bad_version = (tasks.parse_version('11.5.0') <= pki_version
                        < tasks.parse_version('11.7.0'))
-        with xfail_context(bad_version,
-                           reason="https://pagure.io/freeipa/issue/9606"):
+        with xfail_context(
+            bad_version,
+            reason="https://codeberg.org/freeipa/freeipa/issues/9606"
+        ):
             assert (error_msg in result.stderr_text
                     or new_error_msg in result.stderr_text)
 

--- a/ipatests/test_integration/test_cli_ipa_not_configured.py
+++ b/ipatests/test_integration/test_cli_ipa_not_configured.py
@@ -14,7 +14,7 @@ class TestIPANotConfigured(IntegrationTest):
         Launches ipa backup command on system with ipa server not configured.
         As the server is not configured yet, command should fail and stderr
         should not contain link to /var/log, as no such log is created.
-        Issue URl: https://pagure.io/freeipa/issue/6843
+        Issue URl: https://codeberg.org/freeipa/freeipa/issues/6843
         """
         exp_str = "not configured on this system"
         unexp_str = "/var/log"
@@ -25,7 +25,7 @@ class TestIPANotConfigured(IntegrationTest):
 
     def test_ipa_idrange_fix(self):
         """
-        Test for https://pagure.io/freeipa/issue/9809
+        Test for https://codeberg.org/freeipa/freeipa/issues/9809
         Launch ipa-idrange-fix command when the server is not configured.
         """
         exp_str = "IPA is not configured"

--- a/ipatests/test_integration/test_commands.py
+++ b/ipatests/test_integration/test_commands.py
@@ -284,7 +284,7 @@ class TestIPACommand(IntegrationTest):
         was not enabled in IPA. This test is to check if these types are
         enabled.
 
-        related: https://pagure.io/freeipa/issue/8110
+        related: https://codeberg.org/freeipa/freeipa/issues/8110
         """
         tasks.kinit_admin(self.master)
         dn = DN(("cn", self.master.domain.realm), ("cn", "kerberos"),
@@ -298,7 +298,7 @@ class TestIPACommand(IntegrationTest):
         assert "aes256-sha2:special" in result.stdout_text
 
     def test_certmap_match_issue7520(self):
-        # https://pagure.io/freeipa/issue/7520
+        # https://codeberg.org/freeipa/freeipa/issues/7520
         tasks.kinit_admin(self.master)
         result = self.master.run_command(
             ['ipa', 'certmap-match', paths.IPA_CA_CRT],
@@ -318,7 +318,7 @@ class TestIPACommand(IntegrationTest):
         assert "0 users matched" in result.stdout_text
 
     def test_cert_find_issue7520(self):
-        # https://pagure.io/freeipa/issue/7520
+        # https://codeberg.org/freeipa/freeipa/issues/7520
         tasks.kinit_admin(self.master)
         subject = 'CN=Certificate Authority,O={}'.format(
             self.master.domain.realm)
@@ -339,7 +339,7 @@ class TestIPACommand(IntegrationTest):
         assert '1 certificate matched' in result.stdout_text
 
     def test_cert_find_issue9837(self):
-        # https://pagure.io/freeipa/issue/9837
+        # https://codeberg.org/freeipa/freeipa/issues/9837
         user = 'testuser'
         password = 'Secret123'
         testview = 'testview'
@@ -364,7 +364,7 @@ class TestIPACommand(IntegrationTest):
         self.master.run_command(['ipa', 'user-del', user])
 
     def test_add_permission_failure_issue5923(self):
-        # https://pagure.io/freeipa/issue/5923
+        # https://codeberg.org/freeipa/freeipa/issues/5923
         # error response used to contain bytes instead of text
 
         tasks.kinit_admin(self.master)
@@ -741,7 +741,7 @@ class TestIPACommand(IntegrationTest):
         to apache error log. This test ensures that the password should
         not be log in cleartext.
 
-        related: https://pagure.io/freeipa/issue/8017
+        related: https://codeberg.org/freeipa/freeipa/issues/8017
         """
         hostname = 'test.{}'.format(self.master.domain.name)
         passwd = 'Secret123'
@@ -850,7 +850,7 @@ class TestIPACommand(IntegrationTest):
         self.master.run_command(['chmod', '755', '/'])
 
         # start to look at logs a bit before "now"
-        # https://pagure.io/freeipa/issue/8432
+        # https://codeberg.org/freeipa/freeipa/issues/8432
         since = time.strftime(
             '%Y-%m-%d %H:%M:%S',
             (datetime.now() - timedelta(seconds=10)).timetuple()
@@ -981,7 +981,7 @@ class TestIPACommand(IntegrationTest):
 
     def test_sssd_ifp_access_ipaapi(self):
         # check that ipaapi is allowed to access sssd-ifp for smartcard auth
-        # https://pagure.io/freeipa/issue/7751
+        # https://codeberg.org/freeipa/freeipa/issues/7751
         username = 'admin'
         # get UID for user
         result = self.master.run_command(['ipa', 'user-show', username])
@@ -1048,7 +1048,7 @@ class TestIPACommand(IntegrationTest):
         self.master.run_command(['rm', '-f', filename])
 
     def test_hbac_systemd_user(self):
-        # https://pagure.io/freeipa/issue/7831
+        # https://codeberg.org/freeipa/freeipa/issues/7831
         tasks.kinit_admin(self.master)
         # check for presence
         self.master.run_command(
@@ -1113,7 +1113,7 @@ class TestIPACommand(IntegrationTest):
         assert 'HBAC rule not found' in result.stderr_text
 
     def test_config_show_configured_services(self):
-        # https://pagure.io/freeipa/issue/7929
+        # https://codeberg.org/freeipa/freeipa/issues/7929
         states = {CONFIGURED_SERVICE, ENABLED_SERVICE, HIDDEN_SERVICE}
         dn = DN(
             ('cn', 'HTTP'), ('cn', self.master.hostname), ('cn', 'masters'),
@@ -1205,8 +1205,8 @@ class TestIPACommand(IntegrationTest):
         throw the error 'ipa: ERROR: Type or value exists:' and
         instead gets modified
 
-        This is a test case for Pagure issue
-        https://pagure.io/freeipa/issue/5879
+        This is a test case for Codeberg issue
+        https://codeberg.org/freeipa/freeipa/issues/5879
 
         Steps:
         1. setup a master
@@ -1241,7 +1241,7 @@ class TestIPACommand(IntegrationTest):
         """Check Apache has same TLS versions enabled as crypto policy
 
         This is the regression test for issue
-        https://pagure.io/freeipa/issue/7995.
+        https://codeberg.org/freeipa/freeipa/issues/7995.
         """
         def is_tls_version_enabled(tls_version):
             res = self.master.run_command(
@@ -1393,8 +1393,8 @@ class TestIPACommand(IntegrationTest):
         This test checks that ipa-adtrust-install command runs successfully
         on a system with locale en_IN.UTF-8 without displaying error below
         'IndexError: list index out of range'
-        This is a testcase for Pagure issue
-        https://pagure.io/freeipa/issue/8066
+        This is a testcase for Codeberg issue
+        https://codeberg.org/freeipa/freeipa/issues/8066
         """
         # Set locale to en_IN.UTF-8 in .bashrc file to avoid reboot
         tasks.kinit_admin(self.master)
@@ -1449,7 +1449,7 @@ class TestIPACommand(IntegrationTest):
                          ' available from fedora32 onwards')
 
         # start to look at logs a bit before "now"
-        # https://pagure.io/freeipa/issue/8432
+        # https://codeberg.org/freeipa/freeipa/issues/8432
         since = time.strftime(
             '%Y-%m-%d %H:%M:%S',
             (datetime.now() - timedelta(seconds=10)).timetuple()
@@ -2150,7 +2150,7 @@ class TestIPACommandWithoutReplica(IntegrationTest):
         server context. This test checks that groups have correct userclass
         when external is set to true or false with group-add.
 
-        related: https://pagure.io/freeipa/issue/9349
+        related: https://codeberg.org/freeipa/freeipa/issues/9349
         """
         user_code_script = textwrap.dedent("""
             from ipalib import api, errors
@@ -2178,7 +2178,7 @@ class TestIPACommandWithoutReplica(IntegrationTest):
         that all following group_add calls to add posix groups calls are
         not failing with missing attribute.
 
-        related: https://pagure.io/freeipa/issue/9349
+        related: https://codeberg.org/freeipa/freeipa/issues/9349
         """
         user_code_script2 = textwrap.dedent("""
             from ipalib import api, errors
@@ -2217,7 +2217,7 @@ class TestIPACommandWithoutReplica(IntegrationTest):
             - verify that old error message is not seen in dirsrv error log
             - verify that new error message is seen in dirsrv error log
 
-        related: https://pagure.io/freeipa/issue/9618
+        related: https://codeberg.org/freeipa/freeipa/issues/9618
         """
         test_user1 = 'test_user1'
         test_user2 = 'test_user2'
@@ -2293,7 +2293,7 @@ class TestIPACommandWithoutReplica(IntegrationTest):
 
     def test_empty_ipaconfigstring(self, update_ipaconfigstring):
         """
-        Test for https://pagure.io/freeipa/issue/9794
+        Test for https://codeberg.org/freeipa/freeipa/issues/9794
 
         Test that setting an empty ipaconfigstring does not fail.
         Subsequent calls to ipa subid-stats should also succeed.

--- a/ipatests/test_integration/test_customized_ds_config_install.py
+++ b/ipatests/test_integration/test_customized_ds_config_install.py
@@ -4,7 +4,7 @@ from ipatests.pytest_ipa.integration import tasks
 
 DIRSRV_CONFIG_MODS = """
 # https://fedorahosted.org/freeipa/ticket/4949
-# https://pagure.io/freeipa/issue/8515
+# https://codeberg.org/freeipa/freeipa/issues/8515
 dn: cn=bdb,cn=config,cn=ldbm database,cn=plugins,cn=config
 changetype: modify
 replace: nsslapd-db-locks

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -350,7 +350,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         softhsm_version = tasks.parse_version(
             tasks.get_softhsm_version(self.master))
         with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
-                           'https://pagure.io/freeipa/issue/9920'):
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
             assert wait_until_record_is_signed(
                 self.master.ip, root_zone, timeout=100
             ), "Zone %s is not signed (master)" % root_zone
@@ -377,7 +377,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         softhsm_version = tasks.parse_version(
             tasks.get_softhsm_version(self.master))
         with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
-                           'https://pagure.io/freeipa/issue/9920'):
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
             assert wait_until_record_is_signed(
                 self.master.ip, example_test_zone, timeout=100
             ), "Zone %s is not signed (master)" % example_test_zone
@@ -437,7 +437,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         softhsm_version = tasks.parse_version(
             tasks.get_softhsm_version(self.master))
         with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
-                           'https://pagure.io/freeipa/issue/9920'):
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
             ans = resolve_with_dnssec(self.master.ip, root_zone,
                                       rtype="DNSKEY")
         dnskey_rrset = ans.response.get_rrset(ans.response.answer,
@@ -502,7 +502,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         softhsm_version = tasks.parse_version(
             tasks.get_softhsm_version(self.master))
         with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
-                           'https://pagure.io/freeipa/issue/9920'):
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
             ans = resolve_with_dnssec(
                 self.master.ip, root_zone, rtype="DNSKEY"
             )

--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -255,7 +255,7 @@ def validate_mail(host, id, content):
 
 
 class TestEPN(IntegrationTest):
-    """Test Suite for EPN: https://pagure.io/freeipa/issue/3687
+    """Test Suite for EPN: https://codeberg.org/freeipa/freeipa/issues/3687
     """
 
     num_clients = 1
@@ -349,7 +349,7 @@ class TestEPN(IntegrationTest):
     )
     def test_EPN_config_file(self):
         """Check that the EPN configuration file is installed.
-           https://pagure.io/freeipa/issue/8374
+           https://codeberg.org/freeipa/freeipa/issues/8374
         """
         epn_conf = "/etc/ipa/epn.conf"
         epn_template = "/etc/ipa/epn/expire_msg.template"

--- a/ipatests/test_integration/test_external_ca.py
+++ b/ipatests/test_integration/test_external_ca.py
@@ -621,7 +621,7 @@ class TestExternalCAdirsrvStop(IntegrationTest):
     This test checks if second phase installs successfully when dirsrv
     is stoped.
 
-    related ticket: https://pagure.io/freeipa/issue/6611"""
+    related ticket: https://codeberg.org/freeipa/freeipa/issues/6611"""
     def test_external_ca_dirsrv_stop(self):
 
         # Step 1 of ipa-server-install
@@ -694,7 +694,7 @@ class TestExternalCAInvalidCert(IntegrationTest):
 
 
 class TestExternalCAInvalidIntermediate(IntegrationTest):
-    """Test case for https://pagure.io/freeipa/issue/7877"""
+    """Test case for https://codeberg.org/freeipa/freeipa/issues/7877"""
 
     def test_invalid_intermediate(self):
         install_server_external_ca_step1(self.master)

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -217,7 +217,7 @@ class TestInstallWithCA1(InstallTestBase1):
     def test_install_with_bad_ldap_conf(self):
         """
         Test a client install with a non standard ldap.config
-        https://pagure.io/freeipa/issue/7418
+        https://codeberg.org/freeipa/freeipa/issues/7418
         """
         ldap_conf = paths.OPENLDAP_LDAP_CONF
         base_dn = self.master.domain.basedn
@@ -735,7 +735,7 @@ class TestInstallMaster(IntegrationTest):
     )
     def test_smoke_test_for_debug_mode(self):
         """Test if an IPA server works in debug mode.
-        Related: https://pagure.io/freeipa/issue/8891
+        Related: https://codeberg.org/freeipa/freeipa/issues/8891
 
         Note: this test hardcodes the "httpd" service name.
         """
@@ -763,7 +763,7 @@ class TestInstallMaster(IntegrationTest):
         This is to ensure if said entry is set after installation.
         It also checks if compat tree is disable.
 
-        related: https://pagure.io/freeipa/issue/8193
+        related: https://codeberg.org/freeipa/freeipa/issues/8193
         """
         conn = self.master.ldap_connect()
         entry = conn.get_entry(DN(
@@ -791,7 +791,7 @@ class TestInstallMaster(IntegrationTest):
         for pki-tomcatd. This test validates that restart
         called on pki-tomcat properly.
 
-        related ticket : https://pagure.io/freeipa/issue/7927
+        related ticket : https://codeberg.org/freeipa/freeipa/issues/7927
         """
         # get process id of pki-tomcatd
         pki_pid = get_pki_tomcatd_pid(self.master)
@@ -886,7 +886,7 @@ class TestInstallMaster(IntegrationTest):
     def test_WSGI_worker_process(self):
         """ Test if WSGI worker process count is set to 4
 
-        related ticket : https://pagure.io/freeipa/issue/7587
+        related ticket : https://codeberg.org/freeipa/freeipa/issues/7587
         """
         # check process count in httpd conf file i.e expected string
         exp = b'WSGIDaemonProcess ipa processes=%d' % constants.WSGI_PROCESSES
@@ -907,7 +907,7 @@ class TestInstallMaster(IntegrationTest):
         It needs Yubikey hardware to make command successfull. This test
         just check of proper error thrown when hardware is not attached.
 
-        related ticket : https://pagure.io/freeipa/issue/6979
+        related ticket : https://codeberg.org/freeipa/freeipa/issues/6979
         """
         # try to add yubikey to the user
         args = ['ipa', 'otptoken-add-yubikey', '--owner=admin']
@@ -1049,7 +1049,7 @@ class TestInstallMaster(IntegrationTest):
             assert group_warnings == [], msg.format(group_warnings)
 
     def test_ds_disable_upgrade_hash(self):
-        # Test case for https://pagure.io/freeipa/issue/8315
+        # Test case for https://codeberg.org/freeipa/freeipa/issues/8315
         # Disable password schema migration on LDAP bind
         result = tasks.ldapsearch_dm(
             self.master,
@@ -1081,7 +1081,7 @@ class TestInstallMaster(IntegrationTest):
     def test_nsslapd_sizelimit(self):
         """ Test for default value of nsslapd-sizelimit.
 
-        Related : https://pagure.io/freeipa/issue/8962
+        Related : https://codeberg.org/freeipa/freeipa/issues/8962
         """
         result = tasks.ldapsearch_dm(
             self.master,
@@ -1215,7 +1215,7 @@ class TestInstallMaster(IntegrationTest):
         """
         Test that --hostname parameter is respected in interactive mode.
 
-        https://pagure.io/freeipa/issue/2692
+        https://codeberg.org/freeipa/freeipa/issues/2692
         """
         original_hostname = self.master.hostname
         new_hostname = 'new.' + original_hostname
@@ -1272,7 +1272,7 @@ class TestInstallMaster(IntegrationTest):
         Test if the installer is not dependant on trust-ad package and
         succeeds even when AD subpackage is not installed
 
-        https://pagure.io/freeipa/issue/4011
+        https://codeberg.org/freeipa/freeipa/issues/4011
         """
         if osinfo.id == 'fedora':
             package_name = 'freeipa-server-trust-ad'
@@ -1296,7 +1296,7 @@ class TestInstallMaster(IntegrationTest):
         Test that the installer backs up CS.cfg configuration before it's
         being modified.
 
-        https://pagure.io/freeipa/issue/4166
+        https://codeberg.org/freeipa/freeipa/issues/4166
         """
         bcp_location = paths.CA_CS_CFG_PATH + '.ipabkp'
         original_cfg_content = None
@@ -1343,7 +1343,7 @@ class TestInstallMasterKRA(IntegrationTest):
         This test checks that ipa-ccache-sweep.timer is enabled by default
         during the ipa installation.
 
-        related: https://pagure.io/freeipa/issue/9107
+        related: https://codeberg.org/freeipa/freeipa/issues/9107
         """
         result = self.master.run_command(
             ['systemctl', 'is-enabled', 'ipa-ccache-sweep.timer'],
@@ -1425,7 +1425,7 @@ class TestInstallMasterDNS(IntegrationTest):
         'allow-recursion { any; };'. It also checks if ipa-backup
         command backup the /etc/named/ipa-ext.conf file as well
 
-        related : https://pagure.io/freeipa/issue/8079
+        related : https://codeberg.org/freeipa/freeipa/issues/8079
         """
         # check of /etc/named/ipa-ext.conf exist
         assert self.master.transport.file_exists(paths.NAMED_CUSTOM_CONF)
@@ -1448,7 +1448,7 @@ class TestInstallMasterDNS(IntegrationTest):
         Installer wizard should prompt for DNS even if --setup-dns is not
         provided as an argument.
 
-        https://pagure.io/freeipa/issue/2575
+        https://codeberg.org/freeipa/freeipa/issues/2575
         """
         cmd = ['ipa-server-install']
         netbios = create_netbios_name(self.master)
@@ -1531,7 +1531,7 @@ class TestInstallMasterReservedIPasForwarder(IntegrationTest):
     This test checks if ipa server installation throws an error when
     0.0.0.0 is specified as forwarder IP address.
 
-    related ticket: https://pagure.io/freeipa/issue/6894
+    related ticket: https://codeberg.org/freeipa/freeipa/issues/6894
     """
 
     def test_reserved_ip_as_forwarder(self):
@@ -1576,7 +1576,7 @@ class TestKRAinstallAfterCertRenew(IntegrationTest):
     KRA installation was failing after ca-agent cert gets renewed.
     This test checks if the symptoms no longer exist.
 
-    related ticket: https://pagure.io/freeipa/issue/7288
+    related ticket: https://codeberg.org/freeipa/freeipa/issues/7288
     """
 
     def test_KRA_install_after_cert_renew(self):
@@ -1635,8 +1635,10 @@ class TestKRAinstallAfterCertRenew(IntegrationTest):
             # /root/.dogtag/pki-tomcat/ca_admin.cert is checked
             # and KRA install fails. Known IPA issue
             pki_version = tasks.get_pki_version(self.master)
-            with xfail_context(pki_version >= tasks.parse_version('11.6.0'),
-                               'https://pagure.io/freeipa/issue/9763'):
+            with xfail_context(
+                pki_version >= tasks.parse_version('11.6.0'),
+                'https://codeberg.org/freeipa/freeipa/issues/9763'
+            ):
                 cmd = self.master.run_command([
                     'ipa-kra-install', '-p', dm_pass, '-U'
                 ])
@@ -1650,7 +1652,7 @@ class TestKRAinstallOnReplicaWithCAHost(IntegrationTest):
     KRA install on a replica should fail
     if the ca_host line in /etc/ipa/default.conf is present
 
-    Related: https://pagure.io/freeipa/issue/8245
+    Related: https://codeberg.org/freeipa/freeipa/issues/8245
     """
 
     num_replicas = 1
@@ -1682,7 +1684,7 @@ class TestMaskInstall(IntegrationTest):
     This test checks that master/replica installation fails (expectedly) if
     mask > 022.
 
-    related ticket: https://pagure.io/freeipa/issue/7193
+    related ticket: https://codeberg.org/freeipa/freeipa/issues/7193
     """
     topology = 'star'
 
@@ -1722,7 +1724,7 @@ class TestMaskInstall(IntegrationTest):
 
 
 class TestInstallMasterReplica(IntegrationTest):
-    """https://pagure.io/freeipa/issue/7929
+    """https://codeberg.org/freeipa/freeipa/issues/7929
     Problem:
     If a replica installation fails before all the services
     have been enabled then
@@ -1764,7 +1766,7 @@ class TestInstallMasterReplica(IntegrationTest):
         4. On master,
            run ipa-replica-manage del <replicaFQDN> --cleanup --force
         """
-        # https://pagure.io/freeipa/issue/7929
+        # https://codeberg.org/freeipa/freeipa/issues/7929
         # modify the replica entry on Master
         cmd_output = None
         dn_entry = 'dn: cn=KDC,cn=%s,cn=masters,cn=ipa,' \
@@ -1802,7 +1804,7 @@ class TestInstallReplicaAgainstSpecificServer(IntegrationTest):
     install replica2 from replica1 and expect it to get fail as specified
     server is not providing all the services.
 
-    related ticket: https://pagure.io/freeipa/issue/7566
+    related ticket: https://codeberg.org/freeipa/freeipa/issues/7566
     """
 
     num_replicas = 2
@@ -2004,7 +2006,7 @@ class TestInstallWithoutNamed(IntegrationTest):
     @classmethod
     def remove_named(cls, host):
         # remove the bind package and make sure the named user does not exist.
-        # https://pagure.io/freeipa/issue/8936
+        # https://codeberg.org/freeipa/freeipa/issues/8936
         result = host.run_command(['id', 'named'], raiseonerr=False)
         if result.returncode == 0:
             tasks.uninstall_packages(host, ['bind'])
@@ -2107,7 +2109,7 @@ class TestHostnameValidator(IntegrationTest):
         ]
 
     def test_user_input_hostname(self):
-        # https://pagure.io/freeipa/issue/9111
+        # https://codeberg.org/freeipa/freeipa/issues/9111
         # Validate the user-provided hostname
         self.master.run_command(['hostname', 'fedora'])
         result = self.master.run_command(
@@ -2129,7 +2131,7 @@ class TestHostnameValidator(IntegrationTest):
         assert hostname == self.master.hostname
 
     def test_hostname_with_dot(self):
-        # https://pagure.io/freeipa/issue/9111
+        # https://codeberg.org/freeipa/freeipa/issues/9111
         # Validate the user-provided hostname
         self.master.run_command(['hostname', 'fedora'])
         result = self.master.run_command(
@@ -2151,7 +2153,7 @@ class TestHostnameValidator(IntegrationTest):
         assert hostname == self.master.hostname
 
     def test_hostname_matching_domain(self):
-        # https://pagure.io/freeipa/issue/9003
+        # https://codeberg.org/freeipa/freeipa/issues/9003
         # Prevent hostname from matching the domain
         self.master.run_command(['hostname', self.master.hostname])
         args = self.get_args(self.master)

--- a/ipatests/test_integration/test_installation_client.py
+++ b/ipatests/test_integration/test_installation_client.py
@@ -32,7 +32,7 @@ class TestInstallClient(IntegrationTest):
     def check_dns_lookup_kdc(self, client):
         """Check that dns_lookup_kdc is never set to false.
 
-        https://pagure.io/freeipa/issue/6523
+        https://codeberg.org/freeipa/freeipa/issues/6523
 
         Setting dns_lookup_kdc to False would result in a hardcoded
         configuration which is less reliable in the long run.
@@ -71,7 +71,7 @@ class TestInstallClient(IntegrationTest):
         Test checks for non-existence of param HostKeyAlgorithms in
         ssh_config after client-install.
 
-        related: https://pagure.io/freeipa/issue/8082
+        related: https://codeberg.org/freeipa/freeipa/issues/8082
         """
         tasks.install_client(self.master, self.clients[0],
                              extra_args=['--ssh-trust-dns'])
@@ -86,7 +86,7 @@ class TestInstallClient(IntegrationTest):
         Test checks that krb5.conf does not include
         SSSD_PUBCONF_KRB5_INCLUDE_D_DIR.
 
-        related: https://pagure.io/freeipa/issue/9267
+        related: https://codeberg.org/freeipa/freeipa/issues/9267
         """
         krb5_cfg = self.master.get_file_contents(paths.KRB5_CONF)
         assert 'includedir {dir}'.format(
@@ -211,7 +211,7 @@ class TestClientInstallBind(IntegrationTest):
         and during client-install 'nsupdate -g' fails then it should run with
         second call using unauthenticated nsupdate.
 
-        Related : https://pagure.io/freeipa/issue/8402
+        Related : https://codeberg.org/freeipa/freeipa/issues/8402
         """
         # with pre-configured bind server, install ipa-server without dns.
         tasks.install_master(self.master, setup_dns=False)

--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -159,7 +159,7 @@ class TestIpaCertFix(IntegrationTest):
         """
         Test that ipa-cert-fix succeeds when CSR is missing from CS.cfg
 
-        Test case for https://pagure.io/freeipa/issue/8618
+        Test case for https://codeberg.org/freeipa/freeipa/issues/8618
         Scenario:
         - move the date so that ServerCert cert-pki-ca is expired
         - remove the ca.sslserver.certreq directive from CS.cfg
@@ -223,7 +223,7 @@ class TestIpaCertFix(IntegrationTest):
         to renew them. This certs include subsystem, audit-signing,
         OCSP signing, Dogtag HTTPS, IPA RA agent, LDAP and KDC certs.
 
-        related: https://pagure.io/freeipa/issue/7885
+        related: https://codeberg.org/freeipa/freeipa/issues/7885
         """
         expire_cert_critical(self.master)
 
@@ -247,7 +247,7 @@ class TestIpaCertFix(IntegrationTest):
 
         ipa-cert-fix tool should not work on non ipa system.
 
-        related: https://pagure.io/freeipa/issue/7885
+        related: https://codeberg.org/freeipa/freeipa/issues/7885
         """
         result = self.master.run_command(['ipa-cert-fix', '-v'],
                                          stdin_text='yes\n',
@@ -263,7 +263,7 @@ class TestIpaCertFix(IntegrationTest):
         message. It also checks that underlying command 'pki-server cert-fix'
         should fail to renew the cert.
 
-        related: https://pagure.io/freeipa/issue/8721
+        related: https://codeberg.org/freeipa/freeipa/issues/8721
 
         With https://github.com/dogtagpki/pki/pull/3466, it changed to display
         a warning than failing.
@@ -272,7 +272,7 @@ class TestIpaCertFix(IntegrationTest):
         directive is missing from CS.cfg, ipa-cert-fix dsplay proper warning
         (depending on pki version)
 
-        related: https://pagure.io/freeipa/issue/8890
+        related: https://codeberg.org/freeipa/freeipa/issues/8890
         """
         expire_cert_critical(self.master)
         # pki must be stopped in order to edit CS.cfg
@@ -308,12 +308,12 @@ class TestIpaCertFix(IntegrationTest):
         In order to fix expired certs using ipa-cert-fix, CA cert should be
         valid. If CA cert expired, ipa-cert-fix won't work.
 
-        related: https://pagure.io/freeipa/issue/8721
+        related: https://codeberg.org/freeipa/freeipa/issues/8721
 
         If CA cert is close to expiry, there's no reason to issue new certs
         with short validity period. So, ipa-cert-fix should fail in this case.
 
-        related: https://pagure.io/freeipa/issue/9760
+        related: https://codeberg.org/freeipa/freeipa/issues/9760
         """
         result = self.master.run_command(['ipa-cert-fix', '-v'],
                                          stdin_text='yes\n',
@@ -383,7 +383,7 @@ class TestCertFixKRA(IntegrationTest):
         This test check if ipa-cert-fix renews certs with kra
         certificate installed.
 
-        related: https://pagure.io/freeipa/issue/7885
+        related: https://codeberg.org/freeipa/freeipa/issues/7885
         """
         expire_cert_critical(self.master, setup_kra=True)
 
@@ -448,7 +448,7 @@ class TestCertFixReplica(IntegrationTest):
         This is to check that ipa-cert-fix renews the certificates
         on replica
 
-        related: https://pagure.io/freeipa/issue/7885
+        related: https://codeberg.org/freeipa/freeipa/issues/7885
         """
         # wait for cert expiry
         check_status(self.master, 8, "CA_UNREACHABLE")

--- a/ipatests/test_integration/test_ipahealthcheck.py
+++ b/ipatests/test_integration/test_ipahealthcheck.py
@@ -359,7 +359,7 @@ class TestIpaHealthCheck(IntegrationTest):
         Test if in case no  failures were found, informative string is printed
         in human output.
 
-        https://pagure.io/freeipa/issue/8892
+        https://codeberg.org/freeipa/freeipa/issues/8892
         """
         returncode, output = run_healthcheck(self.master, output_type="human",
                                              failures_only=True)
@@ -370,7 +370,7 @@ class TestIpaHealthCheck(IntegrationTest):
         """
         Test if FIPS is enabled and the check exists.
 
-        https://pagure.io/freeipa/issue/8951
+        https://codeberg.org/freeipa/freeipa/issues/8951
         """
         healthcheck_version = tasks.get_healthcheck_version(self.master)
         if (
@@ -1464,7 +1464,7 @@ class TestIpaHealthCheck(IntegrationTest):
         source.
         The test modifies permissions of ipainstall log file and checks the
         response from healthcheck.
-        https://pagure.io/freeipa/issue/8949
+        https://codeberg.org/freeipa/freeipa/issues/8949
         """
         self.modify_perms_run_healthcheck(
             paths.IPASERVER_INSTALL_LOG, modify_permissions,

--- a/ipatests/test_integration/test_membermanager.py
+++ b/ipatests/test_integration/test_membermanager.py
@@ -247,7 +247,7 @@ class TestMemberManager(IntegrationTest):
         Using ACI modification to demonstrate unability before upgrading
         ipa server.
 
-        Related: https://pagure.io/freeipa/issue/9286
+        Related: https://codeberg.org/freeipa/freeipa/issues/9286
         """
         user, password, group2 = prepare_mbr_manager_upgrade
 

--- a/ipatests/test_integration/test_nfs.py
+++ b/ipatests/test_integration/test_nfs.py
@@ -223,7 +223,7 @@ class TestNFS(IntegrationTest):
         # maybe re-use m1.group(0) if it exists.
         assert m1 is None
 
-        # https://pagure.io/freeipa/issue/7918
+        # https://codeberg.org/freeipa/freeipa/issues/7918
         # check whether idmapd.conf was setup using the IPA domain
         automntclt.run_command([
             "grep", "Domain = %s" % self.master.domain.name, "/etc/idmapd.conf"
@@ -248,7 +248,7 @@ class TestNFS(IntegrationTest):
 
         time.sleep(WAIT_AFTER_UNINSTALL)
 
-        # https://pagure.io/freeipa/issue/7918
+        # https://codeberg.org/freeipa/freeipa/issues/7918
         # test for --idmap-domain DNS
         automntclt.run_command([
             'ipa-client-automount', '--location', 'default',
@@ -270,7 +270,7 @@ class TestNFS(IntegrationTest):
 
         time.sleep(WAIT_AFTER_UNINSTALL)
 
-        # https://pagure.io/freeipa/issue/7918
+        # https://codeberg.org/freeipa/freeipa/issues/7918
         # test for --idmap-domain exampledomain.net
         nfs_domain = "exampledomain.net"
         automntclt.run_command([
@@ -343,7 +343,7 @@ class TestIpaClientAutomountFileRestore(IntegrationTest):
             "ipa-client-automount", "--uninstall", "-U"
         ])
 
-        # https://pagure.io/freeipa/issue/8190
+        # https://codeberg.org/freeipa/freeipa/issues/8190
         # check that no ipa_automount_location is left in sssd.conf
         # also check for autofs_provider for good measure
         grep_automount_in_sssdconf_cmd = \

--- a/ipatests/test_integration/test_otp.py
+++ b/ipatests/test_integration/test_otp.py
@@ -596,7 +596,7 @@ class TestOTPToken(IntegrationTest):
     def test_check_otpd_after_idle_timeout(self, setup_otp_nsslapd):
         """Test for OTP when the LDAP connection timed out.
 
-        Test for : https://pagure.io/freeipa/issue/6587
+        Test for : https://codeberg.org/freeipa/freeipa/issues/6587
 
         ipa-otpd was exiting with failure when LDAP connection timed out.
         Test to verify that when the nsslapd-idletimeout is exceeded (30s idle,

--- a/ipatests/test_integration/test_replica_promotion.py
+++ b/ipatests/test_integration/test_replica_promotion.py
@@ -107,7 +107,7 @@ class TestReplicaPromotionLevel1(ReplicaPromotionBase):
     def test_install_with_host_auth_ind_set(self):
         """ A client shouldn't be able to be promoted if it has
         any auth indicator set in the host principal.
-        https://pagure.io/freeipa/issue/8206
+        https://codeberg.org/freeipa/freeipa/issues/8206
         """
 
         client = self.replicas[0]
@@ -333,7 +333,7 @@ class TestWrongClientDomain(IntegrationTest):
                   a pure client install suite is added this can be
                   moved.
 
-           Ticket https://pagure.io/freeipa/issue/7729
+           Ticket https://codeberg.org/freeipa/freeipa/issues/7729
         """
         client = self.replicas[0]
 
@@ -470,7 +470,7 @@ class TestRenewalMaster(IntegrationTest):
         - when called without principal and password, and without any kerberos
           TGT (it should default to principal=admin and prompt for a password)
 
-          related: https://pagure.io/freeipa/issue/9047
+          related: https://codeberg.org/freeipa/freeipa/issues/9047
         """
         exp_str1 = "Connection from replica to master is OK."
         exp_str2 = "Connection from master to replica is OK"
@@ -544,7 +544,7 @@ class TestReplicaInstallWithExistingEntry(IntegrationTest):
     `cn=ipa-http-delegation,cn=s4u2proxy,cn=etc,$SUFFIX` etc. The situation
     may arise due to incorrect uninstall of replica.
 
-    https://pagure.io/freeipa/issue/7174"""
+    https://codeberg.org/freeipa/freeipa/issues/7174"""
 
     num_replicas = 1
 
@@ -831,7 +831,7 @@ class TestSubCAkeyReplication(IntegrationTest):
 
 class TestReplicaInstallCustodia(IntegrationTest):
     """
-    Pagure Reference: https://pagure.io/freeipa/issue/7518
+    Codeberg Reference: https://codeberg.org/freeipa/freeipa/issues/7518
     """
 
     topology = 'line'
@@ -903,7 +903,7 @@ def restore_etc_hosts(host):
 
 class TestReplicaInForwardZone(IntegrationTest):
     """
-    Pagure Reference: https://pagure.io/freeipa/issue/7369
+    Codeberg Reference: https://codeberg.org/freeipa/freeipa/issues/7369
 
     Scenario: install a replica whose name is in a forwarded zone
     """
@@ -1089,8 +1089,10 @@ class TestHiddenReplicaPromotion(IntegrationTest):
                 or (os_version[0] == 'rhel'
                     and os_version[1][0] == 9
                     and pki_version < tasks.parse_version('11.0.4'))
-            with xfail_context(pki_too_old,
-                               'https://pagure.io/freeipa/issue/8582'):
+            with xfail_context(
+                pki_too_old,
+                'https://codeberg.org/freeipa/freeipa/issues/8582'
+            ):
                 assert returncode == 0
 
     def test_hide_last_visible_server_fails(self):
@@ -1221,7 +1223,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
         tasks.kinit_admin(self.replicas[0])
 
         # restore turns a hidden replica into an enabled replica
-        # https://pagure.io/freeipa/issue/7894
+        # https://codeberg.org/freeipa/freeipa/issues/7894
         self._check_config([self.master, self.replicas[0]])
         self._check_server_role(self.replicas[0], 'enabled')
 
@@ -1253,7 +1255,7 @@ class TestHiddenReplicaPromotion(IntegrationTest):
     def test_hidden_replica_renew_pkinit_cert(self):
         """Renew the PKINIT cert on a hidden replica.
 
-        Test for https://pagure.io/freeipa/issue/9611
+        Test for https://codeberg.org/freeipa/freeipa/issues/9611
         """
         # Get Request ID
         cmd = ['getcert', 'list', '-f', paths.KDC_CERT]
@@ -1296,7 +1298,7 @@ class TestHiddenReplicaKRA(IntegrationTest):
     @pytest.mark.xfail(reason='freeipa ticket 8240', strict=True)
     def test_kra_hidden_no_preconfig(self):
         """Test installing KRA on a replica when all KRAs are hidden.
-           https://pagure.io/freeipa/issue/8240
+           https://codeberg.org/freeipa/freeipa/issues/8240
         """
 
         result = tasks.install_kra(self.replicas[1], raiseonerr=False)
@@ -1314,7 +1316,7 @@ class TestHiddenReplicaKRA(IntegrationTest):
 
     def test_kra_hidden_temp(self):
         """Test for workaround: temporarily un-hide the hidden replica.
-           https://pagure.io/freeipa/issue/8240
+           https://codeberg.org/freeipa/freeipa/issues/8240
         """
         self.replicas[0].run_command([
             'ipa', 'server-state',
@@ -1351,7 +1353,7 @@ class TestReplicaConn(IntegrationTest):
         Administrator@AD.EXAMPLE.COM is used for the deployment
         or promotion of a replica.
 
-        Related : https://pagure.io/freeipa/issue/9542
+        Related : https://codeberg.org/freeipa/freeipa/issues/9542
         """
         self.master.run_command(
             ['ipa', 'idoverrideuser-add', self.adview, self.ad_admin]

--- a/ipatests/test_integration/test_service_permissions.py
+++ b/ipatests/test_integration/test_service_permissions.py
@@ -141,7 +141,7 @@ class TestServicePermissions(IntegrationTest):
 
     def test_service_del(self):
         """ Test that host can add and remove its own services.
-        Related to : https://pagure.io/freeipa/issue/7486"""
+        Related to : https://codeberg.org/freeipa/freeipa/issues/7486"""
 
         self.master.run_command(['kinit', '-kt', '/etc/krb5.keytab'])
         # Add service

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -167,7 +167,7 @@ class TestSMB(IntegrationTest):
             assert file_contents_at_server == test_string
 
             # Detect whether smbclient uses -k or --use-kerberos=required
-            # https://pagure.io/freeipa/issue/8926
+            # https://codeberg.org/freeipa/freeipa/issues/8926
             # then check access using smbclient.
             res = run_smb_client(
                 [
@@ -264,7 +264,7 @@ class TestSMB(IntegrationTest):
         server as its alias. Test that we can actually initialize credentials
         using this alias. We don't need to use it anywhere in Samba, just
         verify that alias works.
-        Test for  https://pagure.io/freeipa/issue/8291"""
+        Test for  https://codeberg.org/freeipa/freeipa/issues/8291"""
         netbiosname = self.smbserver.hostname.split('.')[0].upper() + '$'
         copier = tasks.KerberosKeyCopier(self.smbserver)
 
@@ -422,7 +422,8 @@ class TestSMB(IntegrationTest):
         """Repeatedly try to authenticate with username and password with
         automatic domain discovery.
 
-        This is a regression test for https://pagure.io/freeipa/issue/8636
+        This is a regression test for
+        https://codeberg.org/freeipa/freeipa/issues/8636
         """
         tasks.kdestroy_all(self.smbclient)
 
@@ -467,7 +468,7 @@ class TestSMB(IntegrationTest):
     def test_repeated_uninstall_samba(self):
         """Test samba uninstallation after successful uninstallation.
 
-        Test for bug https://pagure.io/freeipa/issue/8019.
+        Test for bug https://codeberg.org/freeipa/freeipa/issues/8019.
         """
         self.smbserver.run_command(['ipa-client-samba', '--uninstall', '-U'])
 
@@ -475,7 +476,7 @@ class TestSMB(IntegrationTest):
         """Test samba can be reinstalled.
 
         Test installation after uninstallation and do some sanity checks.
-        Test for bug https://pagure.io/freeipa/issue/8021
+        Test for bug https://codeberg.org/freeipa/freeipa/issues/8021
         """
         self.test_install_samba()
         self.test_smb_access_for_ipa_user_at_ipa_client()

--- a/ipatests/test_integration/test_sso.py
+++ b/ipatests/test_integration/test_sso.py
@@ -130,7 +130,7 @@ class TestSsoBridge(IntegrationTest):
         Test case to authenticate via ssh to IPA client as Keycloak
         user with password set in IPA without using external IdP
 
-        related: https://pagure.io/freeipa/issue/9250
+        related: https://codeberg.org/freeipa/freeipa/issues/9250
         """
         username = "kcuser1"
         password = self.keycloak.config.admin_password

--- a/ipatests/test_integration/test_sssd.py
+++ b/ipatests/test_integration/test_sssd.py
@@ -522,7 +522,7 @@ class TestSSSDWithAdTrust(IntegrationTest):
         Verify that query to the AD specific attributes for a
         user or a group directly is successful.
 
-        Related : https://pagure.io/freeipa/issue/9127
+        Related : https://codeberg.org/freeipa/freeipa/issues/9127
         """
         tasks.remove_trust_with_ad(self.master, self.ad.domain.name,
                                    self.ad.hostname)
@@ -672,7 +672,7 @@ class TestNestedMembers(IntegrationTest):
 
         clear_sssd_cache(client)
 
-        # Workaround for https://pagure.io/freeipa/issue/9615
+        # Workaround for https://codeberg.org/freeipa/freeipa/issues/9615
         # Make sure that / on the client has expected permissions
         client.run_command(['chmod', '755', '/'])
 

--- a/ipatests/test_integration/test_subids.py
+++ b/ipatests/test_integration/test_subids.py
@@ -259,7 +259,7 @@ class TestSubordinateId(IntegrationTest):
         """
         Test if subid-match command shows UID of the owner instead of DN
 
-        https://pagure.io/freeipa/issue/8977
+        https://codeberg.org/freeipa/freeipa/issues/8977
         """
         uid = "admin"
         self.subid_generate(uid)

--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -140,7 +140,7 @@ class TestSudo(IntegrationTest):
     def test_advise_script_enable_sudo_admins(self):
         """
             Test for advise scipt to add sudo permissions for admin users
-            https://pagure.io/freeipa/issue/7538
+            https://codeberg.org/freeipa/freeipa/issues/7538
         """
         result = self.master.run_command('ipa-advise enable_admins_sudo')
         script = result.stdout_text

--- a/ipatests/test_integration/test_trust.py
+++ b/ipatests/test_integration/test_trust.py
@@ -27,7 +27,7 @@ def skip_in_fips_mode_due_to_issue_8715(test_method):
     def wrapper(instance):
         if fips.is_fips_enabled(instance.master):
             pytest.skip('Skipping in FIPS mode due to '
-                        'https://pagure.io/freeipa/issue/8715')
+                        'https://codeberg.org/freeipa/freeipa/issues/8715')
         else:
             test_method(instance)
     return wrapper
@@ -406,7 +406,7 @@ class TestTrust(BaseTestTrust):
         error with 'Invalid credentials' thrown when AD user tries to run
         IPA commands.
 
-        related: https://pagure.io/freeipa/issue/8163
+        related: https://codeberg.org/freeipa/freeipa/issues/8163
         """
         tasks.kdestroy_all(self.master)
         ad_admin = 'Administrator@%s' % self.ad_domain
@@ -669,7 +669,8 @@ class TestTrust(BaseTestTrust):
         check that requests from IPA for suffix.ad.test
         are properly routed to ad.test.
 
-        This is a regression test for https://pagure.io/freeipa/issue/8554
+        This is a regression test for
+        https://codeberg.org/freeipa/freeipa/issues/8554
         """
 
         # Create subordinate UPN suffix
@@ -726,7 +727,7 @@ class TestTrust(BaseTestTrust):
         and ssh with this ticket should be successful
         with no password prompt.
 
-        Related : https://pagure.io/freeipa/issue/9316
+        Related : https://codeberg.org/freeipa/freeipa/issues/9316
         """
         testuser = 'testuser@{0}'.format(self.ad_domain)
         testusersub = 'subdomaintestuser@{0}'.format(self.ad_subdomain)
@@ -838,7 +839,7 @@ class TestTrust(BaseTestTrust):
     def test_extdom_plugin(self):
         """Extdom plugin should not return error (32)/'No such object'
 
-        Regression test for https://pagure.io/freeipa/issue/8044
+        Regression test for https://codeberg.org/freeipa/freeipa/issues/8044
 
         If there is a timeout during a request to SSSD the extdom plugin
         should not return error 'No such object' and the existing user should
@@ -1234,7 +1235,8 @@ class TestTrust(BaseTestTrust):
         The SRV records for AD services can point to hosts unreachable for
         ipa master. In this case we must be able to establish trust and
         fetch domains list by using "--server" option.
-        This is the regression test for https://pagure.io/freeipa/issue/7895.
+        This is the regression test for
+        https://codeberg.org/freeipa/freeipa/issues/7895.
         """
         # To simulate Windows Server advertising unreachable hosts in SRV
         # records we create specially crafted zone file for BIND DNS server
@@ -1344,7 +1346,7 @@ class TestTrust(BaseTestTrust):
 class TestNonPosixAutoPrivateGroup(BaseTestTrust):
     """
     Tests for auto-private-groups option with non posix AD trust
-    Related : https://pagure.io/freeipa/issue/8807
+    Related : https://codeberg.org/freeipa/freeipa/issues/8807
     """
     topology = 'line'
     num_ad_domains = 1
@@ -1398,8 +1400,10 @@ class TestNonPosixAutoPrivateGroup(BaseTestTrust):
             bad_version = (tasks.parse_version("2.8.2") <= sssd_version
                            < tasks.parse_version("2.9.4"))
             cond = (type == 'hybrid') and bad_version
-            with xfail_context(condition=cond,
-                               reason="https://pagure.io/freeipa/issue/9295"):
+            with xfail_context(
+                condition=cond,
+                reason="https://codeberg.org/freeipa/freeipa/issues/9295"
+            ):
                 (uid, gid) = self.get_user_id(self.clients[0], nonposixuser)
                 assert (uid == self.uid_override and gid == self.gid_override)
             test_group = self.clients[0].run_command(
@@ -1435,7 +1439,7 @@ class TestNonPosixAutoPrivateGroup(BaseTestTrust):
 class TestPosixAutoPrivateGroup(BaseTestTrust):
     """
     Tests for auto-private-groups option with posix AD trust
-    Related : https://pagure.io/freeipa/issue/8807
+    Related : https://codeberg.org/freeipa/freeipa/issues/8807
     """
     topology = 'line'
     num_ad_domains = 1
@@ -1486,7 +1490,7 @@ class TestPosixAutoPrivateGroup(BaseTestTrust):
             bad_version = (tasks.parse_version("2.8.2") <= sssd_version
                            < tasks.parse_version("2.9.4"))
             with xfail_context(bad_version,
-                 "https://pagure.io/freeipa/issue/9295"):
+                 "https://codeberg.org/freeipa/freeipa/issues/9295"):
                 (uid, gid) = self.get_user_id(self.clients[0], posixuser)
                 assert uid == gid
         else:

--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -133,7 +133,7 @@ class TestUninstallWithoutDNS(IntegrationTest):
         IPA server uninstall was failing if dns was not setup.
         This test check if it uninstalls properly.
 
-        related: https://pagure.io/freeipa/issue/8630
+        related: https://codeberg.org/freeipa/freeipa/issues/8630
         """
         tasks.uninstall_master(self.master)
 
@@ -223,7 +223,7 @@ class TestUninstallReinstall(IntegrationTest):
     """Test install, uninstall, re-install.
 
        Reinstall with PKI 11.6.0 was failing
-       https://pagure.io/freeipa/issue/9673
+       https://codeberg.org/freeipa/freeipa/issues/9673
     """
 
     num_replicas = 0
@@ -243,7 +243,7 @@ class TestUninstallCRLGen(IntegrationTest):
     """Test uninstallation of a replica with broken CRL configuration.
 
        Removing ca.crl.MasterCRL.enableCRLCache from CS.cfg crashed.
-       https://pagure.io/freeipa/issue/9921
+       https://codeberg.org/freeipa/freeipa/issues/9921
     """
 
     num_replicas = 1

--- a/ipatests/test_integration/test_upgrade.py
+++ b/ipatests/test_integration/test_upgrade.py
@@ -418,7 +418,7 @@ class TestUpgrade(IntegrationTest):
     def test_kra_detection(self):
         """Test that ipa-server-upgrade correctly detects KRA presence
 
-        Test for https://pagure.io/freeipa/issue/8596
+        Test for https://codeberg.org/freeipa/freeipa/issues/8596
         When the directory /var/lib/pki/pki-tomcat/kra/ exists, the upgrade
         wrongly assumes that KRA component is installed and crashes.
         The test creates an empty dir and calls kra.is_installed()
@@ -448,7 +448,7 @@ class TestUpgrade(IntegrationTest):
     def test_krb_uri_txt_to_cname(self, setup_locations):
         """Test that ipa-server-upgrade correctly updates Kerberos DNS records
 
-        Test for https://pagure.io/freeipa/issue/9257
+        Test for https://codeberg.org/freeipa/freeipa/issues/9257
         Kerberos URI and TXT DNS records should be location-aware in case the
         server is part of a location, in order for DNS discovery to prioritize
         servers from the same location. This means that for such servers the

--- a/ipatests/test_integration/test_user_permissions.py
+++ b/ipatests/test_integration/test_user_permissions.py
@@ -223,7 +223,7 @@ class TestUserPermissions(IntegrationTest):
         """
         Test that non admin user can search hbac rule.
 
-        Related : https://pagure.io/freeipa/issue/5130
+        Related : https://codeberg.org/freeipa/freeipa/issues/5130
         """
         user = 'hbacuser'
         password = 'Secret123'
@@ -255,7 +255,7 @@ class TestInstallClientNoAdmin(IntegrationTest):
 
         In ipaclient-install.log it should use the username that was entered
         earlier in the install process at the prompt.
-        Related to : https://pagure.io/freeipa/issue/5406
+        Related to : https://codeberg.org/freeipa/freeipa/issues/5406
         """
         client = self.clients[0]
         tasks.install_master(self.master)

--- a/ipatests/test_ipalib/test_x509.py
+++ b/ipatests/test_ipalib/test_x509.py
@@ -286,7 +286,7 @@ class test_x509:
         """
         Test the not_before and not_after values in a diffent timezone
 
-        Test for https://pagure.io/freeipa/issue/9462
+        Test for https://codeberg.org/freeipa/freeipa/issues/9462
         """
         # Store initial timezone, then set to New York
         tz = os.environ.get('TZ', None)

--- a/ipatests/test_webui/test_group.py
+++ b/ipatests/test_webui/test_group.py
@@ -421,7 +421,7 @@ class test_group(UI_driver):
     @screenshot
     def test_settings_new_columns(self):
         '''
-        Related: https://pagure.io/freeipa/issue/9390
+        Related: https://codeberg.org/freeipa/freeipa/issues/9390
         Test that the new columns 'givenname', 'sn' and 'nsaccountlock'
         are visible when creating new user groups and inspecting its
         'settings' section.

--- a/ipatests/test_webui/test_loginscreen.py
+++ b/ipatests/test_webui/test_loginscreen.py
@@ -419,7 +419,7 @@ class TestLoginScreen(UI_driver):
         Verify logging as root, using admin password.
         Root should be recognized as an alias for admin user.
 
-        Related: https://pagure.io/freeipa/issue/9226
+        Related: https://codeberg.org/freeipa/freeipa/issues/9226
         """
         self.load()
         assert self.login_screen_visible()

--- a/ipatests/test_webui/test_navigation.py
+++ b/ipatests/test_webui/test_navigation.py
@@ -180,7 +180,7 @@ class test_navigation(UI_driver):
         navigates to target (desired behaviour) compared to creation of copy of
         current state of page on new tab (old behaviour).
 
-        Related: https://pagure.io/freeipa/issue/7137
+        Related: https://codeberg.org/freeipa/freeipa/issues/7137
         """
         self.init_app()
         crubs = {

--- a/ipatests/test_webui/test_pwpolicy.py
+++ b/ipatests/test_webui/test_pwpolicy.py
@@ -282,7 +282,7 @@ class test_pwpolicy(UI_driver):
         """
         Verify existence of grace login limit field and its constraints
 
-        Related: https://pagure.io/freeipa/issue/9211
+        Related: https://codeberg.org/freeipa/freeipa/issues/9211
         """
         self.init_app()
         self.add_record(group.ENTITY, [group.DATA])

--- a/ipatests/test_webui/test_range.py
+++ b/ipatests/test_webui/test_range.py
@@ -71,7 +71,8 @@ class test_range(range_tasks):
         self.wait_for_request(n=2)
 
         # the user should not be able to change the ID allocation for
-        # IPA domain, as it's explained in https://pagure.io/freeipa/issue/4826
+        # IPA domain, as it's explained in
+        # https://codeberg.org/freeipa/freeipa/issues/4826
         dialog = self.get_last_error_dialog()
         assert ("can not be used to change ID allocation for local IPA domain"
                 in dialog.text)

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -358,7 +358,7 @@ class test_user(user_tasks):
         Long certificate serial no were shown in scientific notation
         at user details page. This test checks that it is no longer shown
         in scientific notation
-        related:https://pagure.io/freeipa/issue/8754
+        related:https://codeberg.org/freeipa/freeipa/issues/8754
         """
         if not self.has_ca():
             self.skip('CA is not configured')
@@ -486,7 +486,7 @@ class test_user(user_tasks):
         Verify existence of grace login limit field and its
         value based on pwpolicy value
 
-        Related: https://pagure.io/freeipa/issue/9211
+        Related: https://codeberg.org/freeipa/freeipa/issues/9211
         """
         self.init_app()
         self.add_record(group.ENTITY, [group.DATA])
@@ -765,7 +765,7 @@ class test_user(user_tasks):
         Test if menu is clickable when there is notification
         in minimized browser window.
 
-        related: https://pagure.io/freeipa/issue/8120
+        related: https://codeberg.org/freeipa/freeipa/issues/8120
         """
         self.init_app()
 
@@ -787,7 +787,7 @@ class test_user(user_tasks):
         Test if valid user created in both ca and
         caless env is enabled by default.
 
-        https://pagure.io/freeipa/issue/8203
+        https://codeberg.org/freeipa/freeipa/issues/8203
         """
         self.init_app()
 
@@ -906,7 +906,8 @@ class TestLifeCycles(UI_driver):
         self.dialog_button_click('ok')
         self.assert_no_error_dialog()
         self.wait(2)
-        # fix assert after https://pagure.io/freeipa/issue/7477 is closed
+        # fix assert after
+        # https://codeberg.org/freeipa/freeipa/issues/7477 is closed
         self.assert_notification(assert_text='1 users(s) staged')
 
         # add new "itest-user2" - one is already staged (should pass)

--- a/ipatests/test_xmlrpc/test_pwpolicy_plugin.py
+++ b/ipatests/test_xmlrpc/test_pwpolicy_plugin.py
@@ -241,7 +241,7 @@ class test_pwpolicy(XMLRPC_test):
         But when minlife == maxlife specfied, It works.
         This test check that error message says what exactly it does.
 
-        related: https://pagure.io/freeipa/issue/9038
+        related: https://codeberg.org/freeipa/freeipa/issues/9038
         """
         # test pwpolicy_mod
         # create a test group

--- a/ipatests/test_xmlrpc/test_service_plugin.py
+++ b/ipatests/test_xmlrpc/test_service_plugin.py
@@ -822,7 +822,8 @@ class test_service(Declarative):
             ),
         ),
 
-        # DN is case insensitive, see https://pagure.io/freeipa/issue/8308
+        # DN is case insensitive, see
+        # https://codeberg.org/freeipa/freeipa/issues/8308
         dict(
             desc=(
                 'Delete the current host (master?) %s HTTP service, should '

--- a/ipatests/test_xmlrpc/test_stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/test_stageuser_plugin.py
@@ -649,7 +649,7 @@ class TestPreserved(XMLRPC_test):
 
 @pytest.mark.tier1
 class TestCustomAttr(XMLRPC_test):
-    """Test for pagure ticket 7597
+    """Test for codeberg ticket 7597
 
     When a staged user is activated, preserved and finally staged again,
     the custom attributes are lost.

--- a/makerpms.sh
+++ b/makerpms.sh
@@ -29,7 +29,7 @@ test ! -f "Makefile" && ./configure --enable-silent-rules \
 make rpms
 
 # Workaround to ignore re-generated *.po files in git repo
-# See https://pagure.io/freeipa/issue/6605
+# See https://codeberg.org/freeipa/freeipa/issues/6605
 git checkout po/*.po ||:
 
 popd

--- a/po/Makefile.hack.in
+++ b/po/Makefile.hack.in
@@ -9,7 +9,7 @@ MSGATTRIB = @MSGATTRIB@
 PYTHON = @PYTHON@
 GIT_BRANCH = @GIT_BRANCH@
 
-# Don't use strip-po[t] as a dependency, https://pagure.io/freeipa/issue/8323
+# Don't use strip-po[t] as a dependency, https://codeberg.org/freeipa/freeipa/issues/8323
 .PHONY: strip-po strip-pot
 strip-pot: $(DOMAIN).pot
 	grep -v '#: ipaclient/remote_plugins/' $(DOMAIN).pot > $(DOMAIN).pot.tmp

--- a/po/Makevars
+++ b/po/Makevars
@@ -41,7 +41,7 @@ PACKAGE_GNU = no
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://pagure.io/freeipa/new_issue
+MSGID_BUGS_ADDRESS = https://codeberg.org/freeipa/freeipa/issues/new
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2026-02-26 23:59+0000\n"
 "Last-Translator: Florence Blanc-Renaud <frenaud@redhat.com>\n"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2025-10-17 18:54+0000\n"
 "Last-Translator: Christian Rohr <christian.rohr@mailbox.org>\n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2026-03-19 18:58+0000\n"
 "Last-Translator: Andi Chandler <andi@gowling.com>\n"

--- a/po/es.po
+++ b/po/es.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2025-11-17 04:09+0000\n"
 "Last-Translator: Emilio Herrera <ehespinosa57@gmail.com>\n"

--- a/po/eu.po
+++ b/po/eu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:06+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.12.0.dev202405281307+git69c6a817c\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2025-09-29 20:18+0000\n"
 "Last-Translator: Pejman Rezaei <prezaei.eu@gmail.com>\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.10.0.dev202103310611+git68a5fe822\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2025-04-03 15:21+0000\n"
 "Last-Translator: Ricky Tigg <ricky.tigg@gmail.com>\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2024-06-27 10:36+0000\n"
 "Last-Translator: Léane GRASSER <leane.grasser@proton.me>\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2021-01-04 18:36+0000\n"
 "Last-Translator: Thomas Dombradi <ddt@atomki.hu>\n"

--- a/po/id.po
+++ b/po/id.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2026-02-07 13:58+0000\n"
 "Last-Translator: Arif Budiman <arifpedia@gmail.com>\n"

--- a/po/ipa.pot
+++ b/po/ipa.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.12.0.dev202405281307+git69c6a817c\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.10.0.dev202204261349+gitfbfd64fc2\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2026-01-19 02:58+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"

--- a/po/kn.po
+++ b/po/kn.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.10.0.dev202206291425+git9a97f9b40\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2024-09-27 09:59+0000\n"
 "Last-Translator: 김인수 <simmon@nplob.com>\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2025-07-24 22:39+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2026-04-26 19:58+0000\n"
 "Last-Translator: Américo Monteiro <a_monteiro@gmx.com>\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2026-04-05 23:58+0000\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-12 12:31+0000\n"
 "Last-Translator: Olesya Gerasimenko <gammaray@basealt.ru>\n"

--- a/po/sk.po
+++ b/po/sk.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:26+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.12.0.dev202405281307+git69c6a817c\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2026-03-15 22:58+0000\n"
 "Last-Translator: Daniel Nylander <po@danielnylander.se>\n"

--- a/po/tg.po
+++ b/po/tg.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:26+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev202006101925+gitba7974bfd\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2024-06-25 12:36+0000\n"
 "Last-Translator: Oğuz Ersen <oguz@ersen.moe>\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2024-11-21 19:38+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: freeipa 4.9.0.dev201908140712+gitc9938e3d8\n"
-"Report-Msgid-Bugs-To: https://pagure.io/freeipa/new_issue\n"
+"Report-Msgid-Bugs-To: https://codeberg.org/freeipa/freeipa/issues/new\n"
 "POT-Creation-Date: 2024-05-28 15:09+0200\n"
 "PO-Revision-Date: 2019-11-11 10:25+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"

--- a/selinux/ipa.if
+++ b/selinux/ipa.if
@@ -443,7 +443,7 @@ interface(`ipa_custodia_stream_connect',`
 ##      Manage apache pid objects.
 ##      The interface is defined by selinux-policy since Fedora 31 and is
 ##      conditionally defined here for Fedora 30.
-##      See https://pagure.io/freeipa/issue/8241.
+##      See https://codeberg.org/freeipa/freeipa/issues/8241.
 ## </summary>
 ## <param name="domain">
 ##      <summary>


### PR DESCRIPTION
FreeIPA upstream is migrating to Codeberg. Move all Pagure links in comments to their URL at Codeberg.

## Summary by Sourcery

Update FreeIPA source, tests, and documentation to reference the new Codeberg hosting and issue tracker instead of Pagure.

Enhancements:
- Refresh comments and references across tests and server/client code to link to Codeberg issue tracker and repositories, aligning with the project’s hosting migration.

Documentation:
- Update design documents, README, man pages, and workshop docs to point to Codeberg issues and repositories instead of Pagure.

Chores:
- Adjust package metadata and auxiliary scripts to use Codeberg URLs for bugs, repository links, and related components.