### PR TITLE
[WIP] Temp commit to test SSSD PR 8819

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -55,12 +55,13 @@ topologies:
     memory: 14750
 
 jobs:
-  fedora-latest/build:
+  sssd-fedora/build:
     requires: []
     priority: 100
     job:
       class: Build
       args:
+        copr: '@sssd/nightly'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
@@ -69,14 +70,16 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
-    requires: [fedora-latest/build]
+  sssd-fedora/test_external_idp:
+    requires: [sssd-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        build_url: '{sssd-fedora/build_url}'
+        update_packages: True
+        copr: 'packit/SSSD-sssd-8819'
+        test_suite: test_integration/test_idp.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 5000
+        topology: *master_2repl_1client


### PR DESCRIPTION
Tentative fix for RHEL-185008

## Summary by Sourcery

Configure PR CI to build and run external IdP integration tests against SSSD PR 8819 using custom Fedora jobs and COPR repositories.

CI:
- Add a dedicated sssd-fedora build job using the @sssd/nightly COPR repository.
- Add an sssd-fedora external IdP pytest job that consumes the custom build, updates packages from the SSSD PR 8819 COPR, and runs the appropriate integration test suite with an updated topology and timeout.