### PR TITLE
Disable Trace method

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 38 - DO NOT REMOVE THIS LINE
+# VERSION 39 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -9,6 +9,8 @@
 <IfModule !lookup_identity_module>
     LoadModule lookup_identity_module modules/mod_lookup_identity.so
 </IfModule>
+
+TraceEnable Off
 
 ProxyRequests Off
 


### PR DESCRIPTION
Disables TRACE method for the /ipa endpoint. Instead returns 405.

Fixes: https://codeberg.org/freeipa/freeipa/issues/9982

## Summary by Sourcery

Bug Fixes:
- Block the TRACE method on the /ipa endpoint to mitigate the related security issue reported in issue #9982.