### PR TITLE
[Backport][ipa-4-13] Disable Trace method

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 38 - DO NOT REMOVE THIS LINE
+# VERSION 39 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -9,6 +9,8 @@
 <IfModule !lookup_identity_module>
     LoadModule lookup_identity_module modules/mod_lookup_identity.so
 </IfModule>
+
+TraceEnable Off
 
 ProxyRequests Off
 


### PR DESCRIPTION
This PR was opened automatically because PR #8451 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Backport configuration changes to the ipa-4-13 branch related to the Apache ipa.conf template, aligning it with the corresponding updates made in master.