### PR TITLE
Stop lockout processing in the postop if max_fail is 0

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-lockout/ipa_lockout.c
+++ b/daemons/ipa-slapi-plugins/ipa-lockout/ipa_lockout.c
@@ -548,12 +548,19 @@ static int ipalockout_postop(Slapi_PBlock *pb)
             tm.tm_year -= 1900;
             tm.tm_mon -= 1;
 
-            if (failedcount >= max_fail) {
-                if ((lockout_duration == 0) ||
-                    (time_now < timegm(&tm) + lockout_duration)) {
-                    /* Within lockout duration */
-                    LOG_ALERT("User %s is locked out. Too many failed authentication attempts.\n", dn);
-                    goto done;
+			/* skip the alert if we have either no fail count or we
+             * aren't enforcing lockout (max_fail == 0). This avoids a
+             * spurious error message but allows the code to fall through
+             * and clear the failed count and failed date values.
+             */
+            if ((failedcount > 0) && (max_fail > 0)) {
+                if (failedcount >= max_fail) {
+                    if ((lockout_duration == 0) ||
+                        (time_now < timegm(&tm) + lockout_duration)) {
+                        /* Within lockout duration */
+                        LOG_ALERT("User %s is locked out. Too many failed authentication attempts.\n", dn);
+                        goto done;
+                    }
                 }
             }
             if (time_now > timegm(&tm) + failcnt_interval) {


### PR DESCRIPTION
For hosts, which have a max_fail = 0 policy by default, this was erroneously reporting "account locked" errors. This is because the slapi functions to get integer values return 0 if the attribute doesn't exist. So we were comparing

if (failedcount >= max_fail) {
    ALERT("User is locked out");
}

There was no actual lockout. The preop operation handled this case correctly.

Fixes: https://codeberg.org/freeipa/freeipa/issues/9820

## Summary by Sourcery

Bug Fixes:
- Skip lockout processing in the post-operation handler when the krbPwdMaxFailure policy value is zero, avoiding false "account locked" errors for hosts with no lockout policy configured.