### PR TITLE
Add referrer-policy

### DIFF
--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 39 - DO NOT REMOVE THIS LINE
+# VERSION 40 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -88,6 +88,7 @@ ServerTokens Prod
   ErrorDocument 401 /ipa/errors/unauthorized.html
   Header always append X-Frame-Options DENY
   Header always set X-Content-Type-Options "nosniff"
+  Header always set Referrer-Policy "strict-origin-when-cross-origin"
   Header setifempty Content-Security-Policy "upgrade-insecure-requests; frame-ancestors 'none'; default-src 'none'; img-src 'self' data:; font-src 'self'; connect-src 'self'; form-action 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'"
 
   # mod_session always sets two copies of the cookie, and this confuses our


### PR DESCRIPTION
This always adds browser default referrer-policy to the header. As explained here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy#browser_compatibility the policy is applicable only for very old browsers or custom clients. This change is a noop for modern browsers, however it should shut up the scanning tools.

## Summary by Sourcery

Enhancements:
- Introduce a Referrer-Policy header configuration in the ipa.conf template to ensure a consistent default policy across deployments.