### PR TITLE
Navigate to Unauthorized page

### DIFF
--- a/install/html/unauthorized.html
+++ b/install/html/unauthorized.html
@@ -30,7 +30,7 @@
 
         <div id="first-time">
             <p>
-                If this is your first time, please <a href="./config/ssbrowser.html">configure your browser</a>.
+                If this is your first time, please <a href="config/ssbrowser.html">configure your browser</a>.
             </p>
         </div>
     </noscript>

--- a/ipatests/test_webui/test_translation.py
+++ b/ipatests/test_webui/test_translation.py
@@ -42,7 +42,7 @@ class ConfigPageBase(UI_driver):
         host = self.config.get('ipa_server')
         if not host:
             self.skip('FreeIPA server hostname not configured')
-        return 'https://%s/ipa/config' % host
+        return 'https://%s/ipa' % host
 
     def files_loaded(self):
         """
@@ -70,8 +70,6 @@ class ConfigPageBase(UI_driver):
         conn = util.create_https_connection(host, cafile=cacert)
         conn.request('GET', self.url)
         response = conn.getresponse()
-        # check successful response from a server
-        assert response.status == 200
         return response.read().decode('utf-8')
 
     def has_no_child(self, tag, child_tag):
@@ -127,7 +125,7 @@ class TestSsbrowserPage(ConfigPageBase):
     Test translation of ssbrowser.html page
     """
 
-    page_name = 'ssbrowser.html'
+    page_name = 'config/ssbrowser.html'
 
     @screenshot
     def test_long_text_of_ssbrowser_page(self):
@@ -146,7 +144,10 @@ class TestUnauthorizedPage(ConfigPageBase):
     Test translation of unauthorized.html page
     """
 
-    page_name = 'unauthorized.html'
+    # We should be testing unauthorized. As in httpd 401,
+    # not just by navigating to the page unauthorized.html,
+    # as nothing redirects here.
+    page_name = 'xxx'
 
     @screenshot
     def test_long_text_of_unauthorized_page(self):


### PR DESCRIPTION
The test used to navigate to unauthorized.html, which is a non-sense, because nothing ever redirects to this page. The page is supplied whenever we hit 401, so any page behind a login makes more sense.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10008

## Summary by Sourcery

Adjust Web UI translation tests and CI configuration to better reflect real-world unauthorized access behavior.

Bug Fixes:
- Update Web UI base URL and page paths so translation tests hit realistic application routes instead of unused endpoints.

Enhancements:
- Clarify the unauthorized page translation test intent by decoupling it from direct navigation to the unused unauthorized.html resource.
- Switch temporary CI job definition to run the Web UI translation test suite on an IPA server topology.

Tests:
- Refine Web UI translation tests for ssbrowser and unauthorized pages to use accurate paths and scenarios.