### PR TITLE
[Backport][ipa-4-13] kdb: skip password expiration for passwordless authentication

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -210,6 +210,7 @@ struct ipadb_e_data {
     char **authz_data;
     bool has_tktpolaux;
     enum ipadb_user_auth user_auth;
+    krb5_timestamp pw_expiration;
     struct ipadb_e_pol_limits pol_limits[IPADB_USER_AUTH_IDX_MAX];
     bool has_sid;
     struct dom_sid *sid;

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -57,6 +57,7 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
     struct ipadb_e_data *ied;
     struct ipadb_e_pol_limits *pol_limits = NULL;
     int valid_auth_indicators = 0, flags = 0;
+    bool passwordless_auth = false;
     krb5_db_entry *client_actual = NULL;
 
 #ifdef KRB5_KDB_FLAG_ALIAS_OK
@@ -111,6 +112,7 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
             pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_OTP]);
         } else if (strcmp(auth_indicator, "radius") == 0) {
             valid_auth_indicators++;
+            passwordless_auth = true;
             if (!(ua & IPADB_USER_AUTH_RADIUS)) {
                 *status = "OTP pre-authentication not allowed for this user.";
                 kerr = KRB5KDC_ERR_POLICY;
@@ -119,6 +121,7 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
             pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_RADIUS]);
         } else if (strcmp(auth_indicator, "pkinit") == 0) {
             valid_auth_indicators++;
+            passwordless_auth = true;
             /* allow PKINIT unconditionally -- it has passed already at this
              * point so some certificate was useful, only apply the limits */
             pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_PKINIT]);
@@ -133,7 +136,7 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
             pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_HARDENED]);
         } else if (strcmp(auth_indicator, "idp") == 0) {
             valid_auth_indicators++;
-            /* Allow hardened even if only password pre-auth is allowed */
+            passwordless_auth = true;
             if (!(ua & IPADB_USER_AUTH_IDP)) {
                 *status = "IdP pre-authentication not allowed for this user.";
                 kerr = KRB5KDC_ERR_POLICY;
@@ -142,7 +145,7 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
             pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_IDP]);
         } else if (strcmp(auth_indicator, "passkey") == 0) {
             valid_auth_indicators++;
-            /* Allow hardened even if only password pre-auth is allowed */
+            passwordless_auth = true;
             if (!(ua & IPADB_USER_AUTH_PASSKEY)) {
                 *status = "Passkey pre-authentication not allowed for this user.";
                 kerr = KRB5KDC_ERR_POLICY;
@@ -158,6 +161,24 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
         if (!(ua & IPADB_USER_AUTH_PASSWORD)) {
             *status = "Non-hardened password authentication not allowed for this user.";
             kerr = KRB5KDC_ERR_POLICY;
+            goto done;
+        }
+    }
+
+    /* When a passwordless method is available, ipadb_parse_ldap_entry() clears
+     * entry->pw_expiration so the KDC does not reject the AS-REQ before
+     * pre-authentication.  Now that pre-auth is complete and we know the
+     * actual method used, enforce password expiration for password-based
+     * authentication. */
+    if (!passwordless_auth && ied->pw_expiration != 0) {
+        krb5_timestamp now;
+        kerr = krb5_timeofday(context, &now);
+        if (kerr)
+            goto done;
+
+        if ((uint32_t)now > (uint32_t)ied->pw_expiration) {
+            *status = "CLIENT KEY EXPIRED";
+            kerr = KRB5KDC_ERR_KEY_EXP;
             goto done;
         }
     }

--- a/daemons/ipa-kdb/ipa_kdb_principals.c
+++ b/daemons/ipa-kdb/ipa_kdb_principals.c
@@ -791,6 +791,7 @@ static krb5_error_code ipadb_parse_ldap_entry(krb5_context kcontext,
     char *princ_sid;
     char **acl_list;
     krb5_timestamp restime;
+    krb5_timestamp pw_exp_from_ldap = 0;
     bool resbool;
     int result;
     int ret;
@@ -879,11 +880,22 @@ static krb5_error_code ipadb_parse_ldap_entry(krb5_context kcontext,
                                            "krbPasswordExpiration", &restime);
     switch (ret) {
     case 0:
-        entry->pw_expiration = restime;
-
-        /* If we are using only RADIUS, we don't know expiration. */
-        if (ua == IPADB_USER_AUTH_RADIUS)
+        pw_exp_from_ldap = restime;
+        /* If the user has any passwordless authentication method available
+         * (RADIUS, PKINIT, passkey, or IdP), skip the password expiration
+         * check here.  The KDC checks pw_expiration before pre-authentication
+         * runs, so keeping it set would block passwordless methods from
+         * even being attempted.
+         *
+         * The real expiration is preserved in ied->pw_expiration so that
+         * ipa_kdcpolicy_check_as() can still enforce it when a password-based
+         * method is actually used. */
+        if (ua & (IPADB_USER_AUTH_RADIUS | IPADB_USER_AUTH_PKINIT |
+                  IPADB_USER_AUTH_IDP | IPADB_USER_AUTH_PASSKEY)) {
             entry->pw_expiration = 0;
+        } else {
+            entry->pw_expiration = restime;
+        }
     case ENOENT:
         break;
     default:
@@ -1150,6 +1162,7 @@ static krb5_error_code ipadb_parse_ldap_entry(krb5_context kcontext,
     }
 
     ied->user_auth = ua;
+    ied->pw_expiration = pw_exp_from_ldap;
 
     /* If enabled, set the otp user string, enabling otp. */
     if (ua & IPADB_USER_AUTH_OTP) {

--- a/ipatests/test_integration/test_idp.py
+++ b/ipatests/test_integration/test_idp.py
@@ -324,6 +324,111 @@ class TestIDPKeycloak(TestIDP):
         self.kinit_idp_keycloak(self.master, self.KEYCLOAK_USER,
                                 keycloak_server=self.client)
 
+    def test_idp_login_with_expired_password(self):
+        """
+        Password expiration must not block passwordless authentication.
+
+        The KDC checks pw_expiration before pre-authentication runs, so
+        when a passwordless method is available the IPA KDB plugin clears
+        pw_expiration to let the request through.  The kdcpolicy plugin
+        then enforces expiration only when a password-based method was
+        actually used.
+
+        This test verifies four scenarios:
+        1. IdP-only user with expired password   -> IdP kinit succeeds
+        2. IdP+password user with expired password -> IdP kinit succeeds
+        3. IdP+password user with expired password -> password kinit fails
+        4. Password-only user with expired password -> password kinit fails
+
+        Related: https://pagure.io/freeipa/issue/XXXX
+        """
+        PAST_EXPIRATION = "20200101000000Z"
+        pwuser = "pwexpireuser"
+        pwuser_password = "Secret123"
+
+        tasks.kinit_admin(self.master)
+        try:
+            # Give the IdP user a password so we can test password kinit
+            # later when both auth types are enabled.
+            self.master.run_command(
+                ["ipa", "passwd", self.KEYCLOAK_USER],
+                stdin_text="{0}\n{0}\n".format(pwuser_password),
+            )
+
+            # Expire the IdP user's password
+            self.master.run_command([
+                "ipa", "user-mod", self.KEYCLOAK_USER,
+                "--password-expiration", PAST_EXPIRATION,
+            ])
+
+            # --- Scenario 1: IdP-only, expired password, IdP kinit ---
+            tasks.clear_sssd_cache(self.master)
+            self.kinit_idp_keycloak(
+                self.master, self.KEYCLOAK_USER,
+                keycloak_server=self.client,
+            )
+
+            # --- Scenario 2 & 3: IdP+password, expired password ---
+            tasks.kinit_admin(self.master)
+            self.master.run_command([
+                "ipa", "user-mod", self.KEYCLOAK_USER,
+                "--user-auth-type=idp", "--user-auth-type=password",
+            ])
+            tasks.clear_sssd_cache(self.master)
+
+            # Scenario 2: IdP kinit must still succeed
+            self.kinit_idp_keycloak(
+                self.master, self.KEYCLOAK_USER,
+                keycloak_server=self.client,
+            )
+
+            # Scenario 3: password kinit must fail
+            tasks.kdestroy_all(self.master)
+            result = tasks.kinit_as_user(
+                self.master, self.KEYCLOAK_USER, pwuser_password,
+                raiseonerr=False,
+            )
+            assert result.returncode != 0, (
+                "kinit should fail for idp+password user authenticating "
+                "with expired password"
+            )
+
+            # --- Scenario 4: password-only user, expired password ---
+            tasks.kinit_admin(self.master)
+            tasks.user_add(
+                self.master, pwuser, password=pwuser_password,
+                extra_args=["--user-auth-type=password"],
+            )
+            self.master.run_command([
+                "ipa", "user-mod", pwuser,
+                "--password-expiration", PAST_EXPIRATION,
+            ])
+            tasks.kdestroy_all(self.master)
+            tasks.clear_sssd_cache(self.master)
+
+            result = tasks.kinit_as_user(
+                self.master, pwuser, pwuser_password,
+                raiseonerr=False,
+            )
+            assert result.returncode != 0, (
+                "kinit should fail for password-only user with expired "
+                "password"
+            )
+        finally:
+            tasks.kdestroy_all(self.master)
+            tasks.kinit_admin(self.master)
+            # Restore KEYCLOAK_USER to idp-only with no expiration
+            self.master.run_command([
+                "ipa", "user-mod", self.KEYCLOAK_USER,
+                "--user-auth-type=idp",
+            ], raiseonerr=False)
+            self.master.run_command([
+                "ipa", "user-mod", self.KEYCLOAK_USER,
+                "--password-expiration", "29991231235959Z",
+            ], raiseonerr=False)
+            tasks.user_del(self.master, pwuser, raiseonerr=False)
+            tasks.clear_sssd_cache(self.master)
+
     @pytest.fixture
     def hbac_setup_teardown(self):
         tasks.kinit_admin(self.master)


### PR DESCRIPTION
This PR was opened automatically because PR #8411 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Ensure Kerberos password expiration does not block passwordless authentication methods while still enforcing expiration for password-based logins.

New Features:
- Support passwordless Kerberos authentication (IdP, RADIUS, PKINIT, passkey) even when the user’s password is expired by deferring expiration enforcement to kdcpolicy based on the actual method used.

Enhancements:
- Track password expiration separately in IPA KDB entry data to allow conditional enforcement depending on the chosen authentication method.
- Extend kdcpolicy logic to recognize passwordless authentication indicators and only apply password expiration checks when a password-based method is used.

Tests:
- Add integration test coverage for IdP and password authentication combinations with expired passwords to verify correct success and failure behavior across scenarios.