### PR TITLE
[Backport][ipa-4-13] Navigate to Unauthorized page

### DIFF
--- a/install/html/unauthorized.html
+++ b/install/html/unauthorized.html
@@ -30,7 +30,7 @@
 
         <div id="first-time">
             <p>
-                If this is your first time, please <a href="./config/ssbrowser.html">configure your browser</a>.
+                If this is your first time, please <a href="config/ssbrowser.html">configure your browser</a>.
             </p>
         </div>
     </noscript>

--- a/ipatests/test_webui/test_translation.py
+++ b/ipatests/test_webui/test_translation.py
@@ -42,7 +42,7 @@ class ConfigPageBase(UI_driver):
         host = self.config.get('ipa_server')
         if not host:
             self.skip('FreeIPA server hostname not configured')
-        return 'https://%s/ipa/config' % host
+        return 'https://%s/ipa' % host
 
     def files_loaded(self):
         """
@@ -70,8 +70,6 @@ class ConfigPageBase(UI_driver):
         conn = util.create_https_connection(host, cafile=cacert)
         conn.request('GET', self.url)
         response = conn.getresponse()
-        # check successful response from a server
-        assert response.status == 200
         return response.read().decode('utf-8')
 
     def has_no_child(self, tag, child_tag):
@@ -127,7 +125,7 @@ class TestSsbrowserPage(ConfigPageBase):
     Test translation of ssbrowser.html page
     """
 
-    page_name = 'ssbrowser.html'
+    page_name = 'config/ssbrowser.html'
 
     @screenshot
     def test_long_text_of_ssbrowser_page(self):
@@ -146,7 +144,10 @@ class TestUnauthorizedPage(ConfigPageBase):
     Test translation of unauthorized.html page
     """
 
-    page_name = 'unauthorized.html'
+    # We should be testing unauthorized. As in httpd 401,
+    # not just by navigating to the page unauthorized.html,
+    # as nothing redirects here.
+    page_name = 'xxx'
 
     @screenshot
     def test_long_text_of_unauthorized_page(self):


### PR DESCRIPTION
This PR was opened automatically because PR #8457 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Update Web UI translation tests and unauthorized page links to reflect new application paths and behavior.

Documentation:
- Fix the link to the browser configuration page on unauthorized.html to use the correct relative path.

Tests:
- Adjust Web UI translation tests to use the IPA root URL, remove strict HTTP 200 assertion, and update target paths for ssbrowser and unauthorized pages.