### PR TITLE
[Backport][ipa-4-13] Stop lockout processing in the postop if max_fail is 0

### DIFF
--- a/daemons/ipa-slapi-plugins/ipa-lockout/ipa_lockout.c
+++ b/daemons/ipa-slapi-plugins/ipa-lockout/ipa_lockout.c
@@ -548,12 +548,19 @@ static int ipalockout_postop(Slapi_PBlock *pb)
             tm.tm_year -= 1900;
             tm.tm_mon -= 1;
 
-            if (failedcount >= max_fail) {
-                if ((lockout_duration == 0) ||
-                    (time_now < timegm(&tm) + lockout_duration)) {
-                    /* Within lockout duration */
-                    LOG_ALERT("User %s is locked out. Too many failed authentication attempts.\n", dn);
-                    goto done;
+			/* skip the alert if we have either no fail count or we
+             * aren't enforcing lockout (max_fail == 0). This avoids a
+             * spurious error message but allows the code to fall through
+             * and clear the failed count and failed date values.
+             */
+            if ((failedcount > 0) && (max_fail > 0)) {
+                if (failedcount >= max_fail) {
+                    if ((lockout_duration == 0) ||
+                        (time_now < timegm(&tm) + lockout_duration)) {
+                        /* Within lockout duration */
+                        LOG_ALERT("User %s is locked out. Too many failed authentication attempts.\n", dn);
+                        goto done;
+                    }
                 }
             }
             if (time_now > timegm(&tm) + failcnt_interval) {


### PR DESCRIPTION
This PR was opened automatically because PR #8455 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Bug Fixes:
- Prevent spurious account lockout alerts when max_fail is 0 or there are zero failed authentication attempts.