### PR TITLE
ipatests: Fix EPN Postfix TLS setup for FIPS mode

### DIFF
--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -180,6 +180,8 @@ def configure_starttls(host):
     postconf(host, 'smtpd_tls_session_cache_timeout = 3600s')
     # announce STARTTLS support to remote SMTP clients, not require
     postconf(host, 'smtpd_tls_security_level = may')
+    postconf(host, 'smtpd_tls_fingerprint_digest = sha256')
+    postconf(host, 'smtp_tls_fingerprint_digest = sha256')
     host.run_command(["systemctl", "restart", "postfix"])
 
 
@@ -206,9 +208,8 @@ def configure_ssl_client_cert(host):
     postconf(host, "smtpd_tls_req_ccert = yes")
     # CA certificates of root CAs trusted to sign remote SMTP client cert
     postconf(host, f"smtpd_tls_CAfile = {paths.IPA_CA_CRT}")
-
-    if host.is_fips_mode:
-        postconf(host, 'smtpd_tls_fingerprint_digest = sha256')
+    postconf(host, 'smtpd_tls_fingerprint_digest = sha256')
+    postconf(host, 'smtp_tls_fingerprint_digest = sha256')
 
     host.run_command(["systemctl", "restart", "postfix"])
 


### PR DESCRIPTION
test_EPN_starttls and test_EPN_ssl fail in FIPS mode because Postfix defaults to MD5 for TLS fingerprint digests, which FIPS blocks. Postfix then disables TLS and returns "454 4.7.0 TLS not available due to local problem" for STARTTLS, or resets the connection on port 465 for SSL. This is not an ipa-epn bug; the failure is in the Postfix TLS setup used by the integration test helpers. Always set smtpd_tls_fingerprint_digest and smtp_tls_fingerprint_digest to sha256 in configure_starttls() and configure_ssl_client_cert(), replacing the previous FIPS-only smtpd digest setting. This matches RHEL guidance for Postfix TLS in FIPS mode.

Related: https://codeberg.org/freeipa/freeipa/issues/10010

## Summary by Sourcery

Bug Fixes:
- Force Postfix SMTP and SMTPS TLS fingerprint digests to SHA-256 in EPN tests to prevent TLS failures in FIPS environments.