### PR TITLE
[Backport][ipa-4-13] ipatests: Fix EPN Postfix TLS setup for FIPS mode

### DIFF
--- a/ipatests/test_integration/test_epn.py
+++ b/ipatests/test_integration/test_epn.py
@@ -180,6 +180,8 @@ def configure_starttls(host):
     postconf(host, 'smtpd_tls_session_cache_timeout = 3600s')
     # announce STARTTLS support to remote SMTP clients, not require
     postconf(host, 'smtpd_tls_security_level = may')
+    postconf(host, 'smtpd_tls_fingerprint_digest = sha256')
+    postconf(host, 'smtp_tls_fingerprint_digest = sha256')
     host.run_command(["systemctl", "restart", "postfix"])
 
 
@@ -206,9 +208,8 @@ def configure_ssl_client_cert(host):
     postconf(host, "smtpd_tls_req_ccert = yes")
     # CA certificates of root CAs trusted to sign remote SMTP client cert
     postconf(host, f"smtpd_tls_CAfile = {paths.IPA_CA_CRT}")
-
-    if host.is_fips_mode:
-        postconf(host, 'smtpd_tls_fingerprint_digest = sha256')
+    postconf(host, 'smtpd_tls_fingerprint_digest = sha256')
+    postconf(host, 'smtp_tls_fingerprint_digest = sha256')
 
     host.run_command(["systemctl", "restart", "postfix"])
 


### PR DESCRIPTION
This PR was opened automatically because PR #8466 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Tests:
- Set Postfix smtpd and smtp TLS fingerprint digest to SHA-256 in EPN integration tests, independent of FIPS mode.