### PR TITLE
[WIP] Temp commit to test dnssec on rawhide

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -55,7 +55,7 @@ topologies:
     memory: 14750
 
 jobs:
-  fedora-latest/build:
+  fedora-rawhide/build:
     requires: []
     priority: 100
     job:
@@ -63,20 +63,47 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-latest
-          name: freeipa/ci-master-f44
-          version: 0.0.1
+        template: &ci-master-frawhide
+          name: freeipa/ci-master-frawhide
+          version: 0.10.1
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
-    requires: [fedora-latest/build]
+  fedora-rawhide/test_dnssec:
+    requires: [fedora-rawhide/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *ci-master-frawhide
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  fedora-rawhide/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-rawhide/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *master_1repl


### PR DESCRIPTION
softhsm-2.7.0-1 is now available on rawhide,
test DNSSEC functionality with the new package.

Known issue with the previous build:
https://pagure.io/freeipa/issue/9920
Failure to sign DNS zone with softhsm 2.7.0 rc1

## Summary by Sourcery

Switch temporary CI configuration to use Fedora Rawhide and run DNSSEC-focused integration tests against the new softhsm package.

New Features:
- Add Fedora Rawhide build job using the ci-master-frawhide template in the temporary CI configuration.
- Add DNSSEC integration test job on Fedora Rawhide to validate zone signing with the new softhsm package.
- Add two Fedora Rawhide backup-and-restore jobs specifically exercising DNSSEC-related backup and reinstall/restore scenarios.

CI:
- Replace the Fedora latest temporary build/test job with Fedora Rawhide-specific jobs to exercise DNSSEC functionality with updated dependencies.