### PR TITLE
ipatests: Fix replica reinstall in test_server_del

### DIFF
--- a/ipatests/test_integration/test_server_del.py
+++ b/ipatests/test_integration/test_server_del.py
@@ -201,6 +201,8 @@ class TestServerDel(ServerDelBase):
 
         # reinstall the replica
         tasks.uninstall_master(self.replica1)
+        tasks.kinit_admin(self.master)
+        tasks.add_a_record(self.master, self.replica1)
         tasks.install_replica(self.master, self.replica1, setup_ca=True)
 
     def test_ignore_topology_disconnect_replica2(self):
@@ -216,6 +218,8 @@ class TestServerDel(ServerDelBase):
 
         # reinstall the replica
         tasks.uninstall_master(self.replica2, verbose=True)
+        tasks.kinit_admin(self.master)
+        tasks.add_a_record(self.master, self.replica2)
         tasks.install_replica(self.master, self.replica2, setup_ca=True)
 
     def test_removal_of_master_disconnects_both_topologies(self):


### PR DESCRIPTION
After server-del removes a replica, reinstalling it failed because the host DNS record was gone. Re-kinit as admin and recreate the A record before ipa-replica-install.

## Summary by Sourcery

Ensure IPA replica reinstall succeeds after server deletion by restoring required DNS state in integration tests.

Bug Fixes:
- Prevent replica reinstall failures in server deletion tests by recreating the DNS A record before installation.

Tests:
- Update server deletion integration tests to re-authenticate as admin and restore DNS records prior to replica reinstall.