### PR TITLE
[WIP] ipatests: Increase timeout for trust-add scenario

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -76,7 +76,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_trust.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10596
+        topology: *adroot_adchild_adtree_master_1client

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -704,6 +704,7 @@ def configure_dns_for_trust(master, *ad_hosts):
                                 ])
 
 
+
 def unconfigure_dns_for_trust(master, *ad_hosts):
     """
     This undoes changes made by configure_dns_for_trust
@@ -769,7 +770,7 @@ def establish_trust_with_ad(master, ad_domain, ad_admin=None, extra_args=(),
         stdin_text = master.config.ad_admin_password
     run_repeatedly(
         master, ['ipa', 'trust-add', '--type', 'ad', ad_domain] + extra_args,
-        stdin_text=stdin_text)
+        stdin_text=stdin_text, timeout=120)
     master.run_command(['smbcontrol', 'all', 'debug', '1'])
     clear_sssd_cache(master)
     master.run_command(['systemctl', 'restart', 'krb5kdc.service'])


### PR DESCRIPTION
Currently the tests related to trust are failing in downstream due to the below error.
   
 trust add repeatedly failed 15 times, exceeding the timeout of 30 seconds.
 ipa: ERROR: Failed to call com.redhat.idm.trust.fetch_domains helper. 
 DBus exception is org.freedesktop.DBus.Error.NoReply: Did not receive a reply. 
Possible causes include: the remote application did not send a reply,  the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
    
Increase the timeout from to 120 seconds, to see if this works for downstream tests.
Upstream tests works fine as of now.

## Summary by Sourcery

Increase timeouts and adjust test configuration to improve stability of Active Directory trust integration tests.

Enhancements:
- Increase the IPA trust-add command timeout to 120 seconds when establishing trust with AD.

CI:
- Adjust PR CI configuration references to align with the updated test definitions.

Tests:
- Update the temporary CI job to run the trust integration test suite with a larger overall timeout and AD trust topology.