### PR TITLE
Fix sshd_config permissions regression in ipa-client trigger

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1660,10 +1660,8 @@ if [ -f '/etc/ssh/sshd_config' -a $restore -ge 2 ]; then
     if [ -f '/etc/ssh/sshd_config.d/04-ipa.conf' ]; then
         if ! grep -E -q  '^\s*Include\s*/etc/ssh/sshd_config.d/\*\.conf' /etc/ssh/sshd_config 2> /dev/null ; then
             if ! grep -E -q '^\s*Include\s*/etc/ssh/sshd_config.d/04-ipa\.conf' /etc/ssh/sshd_config 2> /dev/null ; then
-                # Include the snippet
-                echo "Include /etc/ssh/sshd_config.d/04-ipa.conf" > /etc/ssh/sshd_config.ipanew
-                cat /etc/ssh/sshd_config >> /etc/ssh/sshd_config.ipanew
-                mv -fZ --backup=existing --suffix .ipaold /etc/ssh/sshd_config.ipanew /etc/ssh/sshd_config
+                # Ensure original permissions (0600) are preserved
+                sed --in-place=.ipaold '1i Include /etc/ssh/sshd_config.d/04-ipa.conf' /etc/ssh/sshd_config
             fi
         fi
     fi


### PR DESCRIPTION
The triggerin scriptlet for openssh-server was using redirection to create a new sshd_config.ipanew file, which inherited the default umask (0644). This resulted in sshd_config becoming world-readable. This patch uses 'install -m 0600' to ensure the temporary file is created with restricted permissions. Jira: https://redhat.atlassian.net/browse/RHEL-210656

## Summary by Sourcery

Bug Fixes:
- Correct sshd_config.ipanew creation to avoid world-readable permissions regression in the ipa-client trigger.