### PR TITLE
[Backport][ipa-4-13] xfail the sudo SSSD offline/caching tests

### DIFF
--- a/ipatests/test_integration/test_sudo.py
+++ b/ipatests/test_integration/test_sudo.py
@@ -20,6 +20,7 @@
 import pytest
 import re
 from ipaplatform.paths import paths
+from ipaplatform.osinfo import osinfo
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration.tasks import (
     clear_sssd_cache, get_host_ip_with_hostmask, remote_sssd_config,
@@ -1607,6 +1608,9 @@ class TestSudo_Functional(IntegrationTest):
         master.run_command([
             "ipa", "group-del", self.GROUP])
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora',
+        reason='freeipa ticket 10000')
     def test_007_sudorule_offline_caching_option_command(self):
         master = self.master
         kinit_admin(master)
@@ -1659,6 +1663,9 @@ class TestSudo_Functional(IntegrationTest):
         clear_sssd_cache(self.client)
         clear_sssd_cache(master)
 
+    @pytest.mark.xfail(
+        osinfo.id == 'fedora',
+        reason='freeipa ticket 10000')
     def test_008_disable_sudorule_offline_caching(self):
         master = self.master
         kinit_admin(master)


### PR DESCRIPTION
These two tests are failing frequently and the sudo tests take hours to complete. Disable them for now while the upstream issue is investigated.

Related: https://pagure.io/freeipa/issue/10000

Signed-off-by: Rob Crittenden <rcritten@redhat.com>
Reviewed-By: Florence Blanc-Renaud <flo@redhat.com>
Reviewed-By: David Hanina <dhanina@redhat.com>

## Summary by Sourcery

Tests:
- Mark sudo offline/caching option and disable tests as xfail on Fedora due to known upstream issue.