### PR TITLE
[Backport][ipa-4-13] ipatests: Add ipa-getcert integration tests (part 2)

### DIFF
--- a/ipatests/test_integration/test_ipa_getcert.py
+++ b/ipatests/test_integration/test_ipa_getcert.py
@@ -111,21 +111,9 @@ EKU_ERR_MSGS = ['Could not evaluate OID']
 
 TOKEN_VERIFY = ['NEED_KEY_PAIR', 'NEWLY_ADDED_NEED_KEYINFO_READ_TOKEN']
 
-PRINCIPAL_VERIFY = ['CA_UNREACHABLE', 'CA_UNCONFIGURED', 'NEED_KEY_PAIR']
-
 KEYSIZE_VERIFY = ['NEED_KEY_PAIR', 'CA_UNREACHABLE']
 
 PINFILE_VERIFY = ['NEWLY_ADDED_NEED_KEYINFO_READ_PIN']
-
-FILE_PRINCIPAL_VERIFY = [
-    'CA_UNREACHABLE', 'CA_UNCONFIGURED',
-    'NEED_KEY_PAIR', 'NEWLY_ADDED_NEED_KEYINFO_READ_PIN',
-]
-
-FILE_KEYSIZE_VERIFY = [
-    'NEED_KEY_PAIR', 'CA_UNREACHABLE',
-    'NEWLY_ADDED_NEED_KEYINFO_READ_PIN',
-]
 
 NSSDB_VALID = "/etc/pki/nssdb"
 NSSDB_INVALID = "/tmp/nonexistent_nssdb"
@@ -157,19 +145,23 @@ class GetcertTestMixin:
     def _assert_verify(self, cmd, expected_statuses):
         """Assert verify test: rc=0, certmonger status checked."""
         assert cmd.returncode == 0
-        match = re.search(
-            r'New .* (?:signing|tracking|) ?request "([^"]+)" added',
-            cmd.stdout_text
-        )
-        if match:
-            status = tasks.wait_for_certmonger_status(
-                self.master, tuple(expected_statuses),
-                match.group(1), timeout=120
+        try:
+            match = re.search(
+                r'New .* (?:signing|tracking|) ?request'
+                r' "([^"]+)" added',
+                cmd.stdout_text
             )
-            assert status in expected_statuses, (
-                "Expected status in %r, got %s"
-                % (expected_statuses, status))
-        clean_requests(self.master)
+            if match:
+                status = tasks.wait_for_certmonger_status(
+                    self.master,
+                    tuple(expected_statuses),
+                    match.group(1), timeout=120
+                )
+                assert status in expected_statuses, (
+                    "Expected status in %r, got %s"
+                    % (expected_statuses, status))
+        finally:
+            clean_requests(self.master)
 
     def _assert_positive(self, cmd):
         """Assert positive test: rc=0, cleanup."""
@@ -338,18 +330,6 @@ class TestGetcertRequest(GetcertTestMixin, IntegrationTest):
         )
         self._assert_verify(cmd, TOKEN_VERIFY)
 
-    def test_request_nss_invalid_principal(self):
-        """request with invalid principal"""
-        test_id = "req_princ_%s" % uuid.uuid4().hex[:8]
-        cmd = self.master.run_command(
-            self._nss_cmd(test_id,
-                          self._full_nss_args(
-                              test_id, renewal="-R",
-                              principal_invalid=True)),
-            raiseonerr=False
-        )
-        self._assert_verify(cmd, PRINCIPAL_VERIFY)
-
     def test_request_nss_invalid_eku(self):
         """request with invalid EKU"""
         test_id = "req_eku_%s" % uuid.uuid4().hex[:8]
@@ -362,9 +342,10 @@ class TestGetcertRequest(GetcertTestMixin, IntegrationTest):
         )
         self._assert_negative(cmd, EKU_ERR_MSGS)
 
-    @pytest.mark.skip(
+    @pytest.mark.xfail(
         reason="Non-numeric key size causes certmonger to "
-        "retry indefinitely, pending certmonger fix"
+        "retry indefinitely. "
+        "https://pagure.io/certmonger/issue/305"
     )
     def test_request_nss_invalid_keysize(self):
         """request with invalid key size"""
@@ -388,15 +369,260 @@ class TestGetcertRequest(GetcertTestMixin, IntegrationTest):
         )
         self._assert_positive(cmd)
 
-    @pytest.mark.parametrize("renewal", ["-R", "-r"])
-    def test_request_nss_positive_full(self, renewal):
-        """request with all valid parameters"""
+    def test_request_nss_positive_full(self):
+        """request with all valid parameters and renewal"""
         test_id = "req_pos_%s" % uuid.uuid4().hex[:8]
         cmd = self.master.run_command(
             self._nss_cmd(test_id,
                           self._full_nss_args(
-                              test_id, renewal=renewal,
+                              test_id, renewal="-R",
                               use_keysize=True)),
             raiseonerr=False
         )
         self._assert_positive(cmd)
+
+    # -- FILE storage tests --
+
+    def test_request_file_invalid_keyfile_basic(self):
+        """request with invalid key file path, no extra args"""
+        test_id = "req_fk_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id, need_key=False)
+        cmd = self.master.run_command(
+            self._file_cmd(test_id, [], key_invalid=True),
+            raiseonerr=False
+        )
+        self._assert_negative(cmd, FILE_KEY_ERR_MSGS)
+
+    def test_request_file_invalid_keyfile_full(self):
+        """request with invalid key file path and full args"""
+        test_id = "req_fk_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id, need_key=False, need_pin=True)
+        cmd = self.master.run_command(
+            self._file_cmd(
+                test_id,
+                self._file_extra_args(
+                    test_id, renewal="-R",
+                    pin_mode='file',
+                    use_keysize=True),
+                key_invalid=True),
+            raiseonerr=False
+        )
+        self._assert_negative(cmd, FILE_KEY_ERR_MSGS)
+
+    def test_request_file_invalid_certfile_basic(self):
+        """request with invalid cert file path, no extra args"""
+        test_id = "req_fc_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id, need_cert=False)
+        cmd = self.master.run_command(
+            self._file_cmd(test_id, [], cert_invalid=True),
+            raiseonerr=False
+        )
+        self._assert_negative(cmd, FILE_CERT_ERR_MSGS)
+
+    def test_request_file_invalid_certfile_full(self):
+        """request with invalid cert file path and full args"""
+        test_id = "req_fc_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id, need_cert=False, need_pin=True)
+        cmd = self.master.run_command(
+            self._file_cmd(
+                test_id,
+                self._file_extra_args(
+                    test_id, renewal="-R",
+                    pin_mode='file',
+                    use_keysize=True),
+                cert_invalid=True),
+            raiseonerr=False
+        )
+        self._assert_negative(cmd, FILE_CERT_ERR_MSGS)
+
+    def test_request_file_positive_basic(self):
+        """request with valid FILE storage, minimal args"""
+        test_id = "req_fp_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id)
+        cmd = self.master.run_command(
+            self._file_cmd(test_id, []),
+            raiseonerr=False
+        )
+        self._assert_positive(cmd)
+
+    @pytest.mark.parametrize("pin_mode", ['inline', 'file'])
+    def test_request_file_invalid_eku(self, pin_mode):
+        """request with invalid EKU in FILE mode"""
+        test_id = "req_fe_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id, need_pin=(pin_mode == 'file'))
+        cmd = self.master.run_command(
+            self._file_cmd(test_id,
+                           self._file_extra_args(
+                               test_id, renewal="-R",
+                               pin_mode=pin_mode,
+                               eku_invalid=True)),
+            raiseonerr=False
+        )
+        self._assert_negative(cmd, EKU_ERR_MSGS)
+
+    def test_request_file_invalid_keysize_fallback(self):
+        """invalid key size falls back to RSA:2048 in FILE mode
+
+        certmonger ignores the non-numeric key size and falls
+        back to the default key type and size (RSA:2048).
+        https://pagure.io/certmonger/issue/305
+        """
+        test_id = "req_fks_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id)
+        keyfile = os.path.join(
+            self.file_dir, '%s.key.pem' % test_id)
+        certfile = os.path.join(
+            self.file_dir, '%s.cert.pem' % test_id)
+        cmd = self.master.run_command([
+            'ipa-getcert', 'request', '-w', '-v',
+            '-k', keyfile, '-f', certfile,
+            '-g', 'shouldBEnumber%s' % test_id,
+        ], raiseonerr=False)
+        assert cmd.returncode == 0, (
+            "Expected request to succeed with fallback "
+            "key size, got rc=%d" % cmd.returncode)
+        result = self.master.run_command(
+            ['openssl', 'pkey', '-in', keyfile,
+             '-text', '-noout']
+        )
+        assert '2048' in result.stdout_text
+        clean_requests(self.master)
+
+    def test_request_file_invalid_pinfile(self):
+        """request with non-existent PIN file"""
+        test_id = "req_fpf_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id)
+        cmd = self.master.run_command(
+            self._file_cmd(test_id,
+                           self._file_extra_args(
+                               test_id, renewal="-R",
+                               pin_mode='file',
+                               pinfile_invalid=True)),
+            raiseonerr=False
+        )
+        self._assert_verify(cmd, PINFILE_VERIFY)
+
+    @pytest.mark.parametrize("pin_mode", ['inline', 'file'])
+    def test_request_file_positive_full(self, pin_mode):
+        """request with all valid FILE storage parameters"""
+        test_id = "req_fp_%s" % uuid.uuid4().hex[:8]
+        self._setup_file(test_id,
+                         need_pin=(pin_mode == 'file'))
+        cmd = self.master.run_command(
+            self._file_cmd(test_id,
+                           self._file_extra_args(
+                               test_id, renewal="-R",
+                               pin_mode=pin_mode,
+                               use_keysize=True)),
+            raiseonerr=False
+        )
+        self._assert_positive(cmd)
+
+    # -- Extended request tests --
+
+    @pytest.fixture
+    def nssdb_tmpdir(self):
+        """Create a temp NSS DB dir and clean up after test."""
+        tmpdir = create_file_dir(self.master)
+        yield tmpdir
+        self.master.run_command(
+            ['ipa-getcert', 'stop-tracking', '-d', tmpdir,
+             '-n', 'certtest'], raiseonerr=False
+        )
+        self.master.run_command(
+            ['rm', '-rf', tmpdir], raiseonerr=False)
+
+    def test_request_ext_with_correct_pin(self, nssdb_tmpdir):
+        """request using NSS database with correct PIN"""
+        create_nss_db_with_pin(self.master, nssdb_tmpdir)
+        self.master.run_command([
+            'ipa-getcert', 'request', '-w', '-v',
+            '-d', nssdb_tmpdir, '-n', 'certtest',
+            '-P', 'temp123#', '-I', 'testing'
+        ])
+        cmd = self.master.run_command(
+            ['ipa-getcert', 'list', '-i', 'testing']
+        )
+        assert 'pin set' in cmd.stdout_text
+
+    def test_request_ext_with_password_file(self,
+                                            nssdb_tmpdir):
+        """request using NSS database with password file"""
+        create_nss_db_with_pin(self.master, nssdb_tmpdir)
+        passwd_file = os.path.join(
+            nssdb_tmpdir, 'passwd.txt')
+        self.master.run_command([
+            'ipa-getcert', 'request', '-w', '-v',
+            '-d', nssdb_tmpdir, '-n', 'certtest',
+            '-p', passwd_file, '-I', 'testing'
+        ])
+        cmd = self.master.run_command(
+            ['ipa-getcert', 'list', '-i', 'testing']
+        )
+        assert 'passwd.txt' in cmd.stdout_text
+
+    def test_request_ext_empty_or_incorrect_pin(
+            self, nssdb_tmpdir):
+        """request using NSS db with incorrect PIN"""
+        create_nss_db_with_pin(self.master, nssdb_tmpdir)
+        cmd = self.master.run_command([
+            'ipa-getcert', 'request', '-w', '-v',
+            '-d', nssdb_tmpdir, '-n', 'certtest',
+            '-I', 'testing', '-P', 'wrong'
+        ], raiseonerr=False)
+        assert cmd.returncode != 0, (
+            "Expected non-zero exit with wrong PIN")
+        result = self.master.run_command(
+            ['ipa-getcert', 'list', '-i', 'testing']
+        )
+        assert 'NEWLY_ADDED_NEED_KEYINFO_READ_PIN' in (
+            result.stdout_text)
+
+    def test_request_ext_incorrect_password_file(
+            self, nssdb_tmpdir):
+        """request using NSS db with incorrect password"""
+        create_nss_db_with_pin(self.master, nssdb_tmpdir)
+        passwd_file = os.path.join(
+            nssdb_tmpdir, 'passwd.txt')
+        self.master.put_file_contents(
+            passwd_file, 'temp123\n'
+        )
+        cmd = self.master.run_command([
+            'ipa-getcert', 'request', '-w', '-v',
+            '-d', nssdb_tmpdir, '-n', 'certtest',
+            '-I', 'testing', '-p', passwd_file
+        ], raiseonerr=False)
+        assert cmd.returncode != 0, (
+            "Expected non-zero exit with wrong password")
+        result = self.master.run_command(
+            ['ipa-getcert', 'list', '-i', 'testing']
+        )
+        assert 'NEWLY_ADDED_NEED_KEYINFO_READ_PIN' in (
+            result.stdout_text)
+
+    def test_request_ext_empty_request_name(self,
+                                            nssdb_tmpdir):
+        """request with empty request name shows usage"""
+        cmd = self.master.run_command(
+            'ipa-getcert request -d %s -n certtest -I 2>&1'
+            % nssdb_tmpdir, raiseonerr=False
+        )
+        assert cmd.returncode == 1
+        assert 'Usage: ipa-getcert request' in (
+            cmd.stdout_text + cmd.stderr_text)
+
+    def test_request_ext_nonexistent_token(self,
+                                           nssdb_tmpdir):
+        """request with non-existent token"""
+        cmd = self.master.run_command([
+            'ipa-getcert', 'request', '-w', '-v',
+            '-d', nssdb_tmpdir, '-n', 'certtest',
+            '-I', 'testing', '-t', 'non-existent'
+        ], raiseonerr=False)
+        assert cmd.returncode != 0, (
+            "Expected non-zero exit with bad token")
+        result = self.master.run_command(
+            ['ipa-getcert', 'list', '-i', 'testing']
+        )
+        assert 'NEWLY_ADDED_NEED_KEYINFO_READ_TOKEN' in (
+            result.stdout_text)


### PR DESCRIPTION
This PR was opened automatically because PR #8329 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Extend ipa-getcert integration coverage for file-based storage and NSS database usage, while adjusting existing NSS tests and cleanup behavior.

New Features:
- Add integration tests for ipa-getcert file-based storage covering valid and invalid key and certificate file paths, EKU values, PIN handling, and full request parameters.
- Add extended integration tests for ipa-getcert requests using temporary NSS databases, including correct and incorrect PINs, password files, empty request names, and non-existent tokens.

Enhancements:
- Ensure certmonger requests are always cleaned up in verification helper via a try/finally block.
- Update invalid key-size NSS test to be expected-to-fail with a reference to the upstream certmonger issue.
- Simplify the full NSS positive request test to use a single renewal option and remove unused principal-related verification constants and test.

Tests:
- Introduce a fixture to provision and tear down temporary NSS databases for extended request tests.