### PR TITLE
[Backport][ipa-4-13] webui tests: add xfail for known issues

### DIFF
--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -254,6 +254,10 @@ class test_host(host_tasks):
         self.delete_record(self.pkey, self.data.get('del'))
 
     @screenshot
+    @pytest.mark.xfail(
+        reason="https://codeberg.org/freeipa/freeipa/issues/9928",
+        strict=True
+    )
     def test_arbitrary_certificates(self):
         """
         Test managing host arbitrary certificate.
@@ -686,6 +690,10 @@ class test_host(host_tasks):
         self.delete(ENTITY, [self.data2])
 
     @screenshot
+    @pytest.mark.xfail(
+        reason="https://codeberg.org/freeipa/freeipa/issues/9928",
+        strict=True
+    )
     def test_negative_cert(self):
         """ Test negative CSR """
         self.init_app()

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -353,6 +353,10 @@ class test_user(user_tasks):
         self.delete_record(user.PKEY, user.DATA.get('del'))
 
     @screenshot
+    @pytest.mark.xfail(
+        reason="https://codeberg.org/freeipa/freeipa/issues/9928",
+        strict=True
+    )
     def test_certificate_serial(self):
         """Test long certificate serial no
         Long certificate serial no were shown in scientific notation


### PR DESCRIPTION
This PR was opened automatically because PR #8491 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Tests:
- Add xfail markers to host and user Web UI certificate tests that are currently failing because of issue 9928, with strict enforcement.