### PR TITLE
ipatests: add xfail depending on softhsm version

### DIFF
--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -34,9 +34,11 @@ from ipapython import ipautil
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 from ipatests.test_integration.test_dnssec import wait_until_record_is_signed
+from ipatests.test_integration.test_dnssec import bad_softhsm_version
 from ipatests.test_integration.test_simple_replication import check_replication
 from ipatests.test_integration.test_topology import find_segment
 from ipatests.util import assert_deepequal
+from ipatests.util import xfail_context
 from ldap.dn import escape_dn_chars
 
 logger = logging.getLogger(__name__)
@@ -404,10 +406,14 @@ class BaseBackupAndRestoreWithDNSSEC(IntegrationTest):
                 '--dnssec', 'true',
             ])
 
-            assert (
-                wait_until_record_is_signed(
-                    self.master.ip, self.example_test_zone)
-            ), "Zone is not signed"
+            with xfail_context(
+                bad_softhsm_version(self.master),
+                'https://codeberg.org/freeipa/freeipa/issues/9920'
+            ):
+                assert (
+                    wait_until_record_is_signed(
+                        self.master.ip, self.example_test_zone)
+                ), "Zone is not signed"
 
             backup_path = tasks.get_backup_dir(self.master)
 

--- a/ipatests/test_integration/test_dnssec.py
+++ b/ipatests/test_integration/test_dnssec.py
@@ -139,6 +139,24 @@ def dnssec_install_master(host):
     return host.run_command(args)
 
 
+def bad_softhsm_version(host):
+    """
+    Return true if the host has softhsm version 2.7.0-0.1.rc1
+    which fails dnssec related tests
+    """
+    platform = tasks.get_platform(host)
+    if platform in ("rhel", "fedora"):
+        cmd = host.run_command(
+            ["rpm", "-qa", "softhsm"]
+        )
+        get_package_version = cmd.stdout_text
+        if not get_package_version:
+            return False
+        if get_package_version.startswith("softhsm-2.7.0-0.1.rc1"):
+            return True
+    return False
+
+
 class TestInstallDNSSECLast(IntegrationTest):
     """Simple DNSSEC test
 
@@ -161,9 +179,11 @@ class TestInstallDNSSECLast(IntegrationTest):
         # add zone with enabled DNSSEC signing on master
         dnszone_add_dnssec(self.master, test_zone)
         # test master
-        assert wait_until_record_is_signed(
-            self.master.ip, test_zone, timeout=100
-        ), "Zone %s is not signed (master)" % test_zone
+        with xfail_context(bad_softhsm_version(self.master),
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
+            assert wait_until_record_is_signed(
+                self.master.ip, test_zone, timeout=100
+            ), "Zone %s is not signed (master)" % test_zone
 
         # test replica
         assert wait_until_record_is_signed(
@@ -174,9 +194,11 @@ class TestInstallDNSSECLast(IntegrationTest):
         # add zone with enabled DNSSEC signing on replica
         dnszone_add_dnssec(self.replicas[0], test_zone_repl)
         # test replica
-        assert wait_until_record_is_signed(
-            self.replicas[0].ip, test_zone_repl, timeout=300
-        ), "Zone %s is not signed (replica)" % test_zone_repl
+        with xfail_context(bad_softhsm_version(self.master),
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
+            assert wait_until_record_is_signed(
+                self.replicas[0].ip, test_zone_repl, timeout=300
+            ), "Zone %s is not signed (replica)" % test_zone_repl
 
         # we do not need to wait, on master zones should be singed faster
         # than on replicas
@@ -186,14 +208,19 @@ class TestInstallDNSSECLast(IntegrationTest):
         ), "DNS zone %s is not signed (master)" % test_zone
 
     def test_key_types(self):
-        assert dnskey_rec_with_ksk_and_zsk(self.master.ip, test_zone)
-        assert dnskey_rec_with_ksk_and_zsk(self.replicas[0].ip, test_zone)
-        assert dnskey_rec_with_ksk_and_zsk(self.master.ip, test_zone_repl)
-        assert dnskey_rec_with_ksk_and_zsk(self.replicas[0].ip, test_zone_repl)
+        with xfail_context(bad_softhsm_version(self.master),
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
+            assert dnskey_rec_with_ksk_and_zsk(self.master.ip, test_zone)
+            assert dnskey_rec_with_ksk_and_zsk(self.replicas[0].ip, test_zone)
+            assert dnskey_rec_with_ksk_and_zsk(self.master.ip, test_zone_repl)
+            assert dnskey_rec_with_ksk_and_zsk(
+                self.replicas[0].ip, test_zone_repl)
 
     def test_disable_reenable_signing_master(self):
-        dnskey_old = resolve_with_dnssec(self.master.ip, test_zone,
-                                         rtype="DNSKEY").rrset
+        with xfail_context(bad_softhsm_version(self.master),
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
+            dnskey_old = resolve_with_dnssec(self.master.ip, test_zone,
+                                             rtype="DNSKEY").rrset
 
         # disable DNSSEC signing of zone on master
         args = [
@@ -240,8 +267,11 @@ class TestInstallDNSSECLast(IntegrationTest):
         assert dnskey_old != dnskey_new, "DNSKEY should be different"
 
     def test_disable_reenable_signing_replica(self):
-        dnskey_old = resolve_with_dnssec(self.replicas[0].ip, test_zone_repl,
-                                         rtype="DNSKEY").rrset
+        with xfail_context(bad_softhsm_version(self.master),
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
+            dnskey_old = resolve_with_dnssec(self.replicas[0].ip,
+                                             test_zone_repl,
+                                             rtype="DNSKEY").rrset
 
         # disable DNSSEC signing of zone on replica
         args = [
@@ -347,9 +377,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         ]
         self.master.run_command(args)
         # test master
-        softhsm_version = tasks.parse_version(
-            tasks.get_softhsm_version(self.master))
-        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+        with xfail_context(bad_softhsm_version(self.master),
                            'https://codeberg.org/freeipa/freeipa/issues/9920'):
             assert wait_until_record_is_signed(
                 self.master.ip, root_zone, timeout=100
@@ -374,9 +402,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         tasks.restart_named(self.master, self.replicas[0])
 
         # wait until zone is signed
-        softhsm_version = tasks.parse_version(
-            tasks.get_softhsm_version(self.master))
-        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+        with xfail_context(bad_softhsm_version(self.master),
                            'https://codeberg.org/freeipa/freeipa/issues/9920'):
             assert wait_until_record_is_signed(
                 self.master.ip, example_test_zone, timeout=100
@@ -434,9 +460,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
         Validate signed DNS records, using our own signed root zone
         """
         # extract DSKEY from root zone
-        softhsm_version = tasks.parse_version(
-            tasks.get_softhsm_version(self.master))
-        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+        with xfail_context(bad_softhsm_version(self.master),
                            'https://codeberg.org/freeipa/freeipa/issues/9920'):
             ans = resolve_with_dnssec(self.master.ip, root_zone,
                                       rtype="DNSKEY")
@@ -499,9 +523,7 @@ class TestInstallDNSSECFirst(IntegrationTest):
             )
 
         # extract DSKEY from root zone
-        softhsm_version = tasks.parse_version(
-            tasks.get_softhsm_version(self.master))
-        with xfail_context(softhsm_version >= tasks.parse_version('2.7.0'),
+        with xfail_context(bad_softhsm_version(self.master),
                            'https://codeberg.org/freeipa/freeipa/issues/9920'):
             ans = resolve_with_dnssec(
                 self.master.ip, root_zone, rtype="DNSKEY"
@@ -654,9 +676,11 @@ class TestMigrateDNSSECMaster(IntegrationTest):
         # add test zone
         dnszone_add_dnssec(self.master, example_test_zone)
         # wait until zone is signed
-        assert wait_until_record_is_signed(
-            self.master.ip, example_test_zone, timeout=100
-        ), "Zone %s is not signed (master)" % example_test_zone
+        with xfail_context(bad_softhsm_version(self.master),
+                           'https://codeberg.org/freeipa/freeipa/issues/9920'):
+            assert wait_until_record_is_signed(
+                self.master.ip, example_test_zone, timeout=100
+            ), "Zone %s is not signed (master)" % example_test_zone
         # wait until zone is signed
         assert wait_until_record_is_signed(
             self.replicas[0].ip, example_test_zone, timeout=200


### PR DESCRIPTION
When softhsm 2.7.0-0.1.rc1 is installed, all DNSSEC-related tests are failing. Add xfail annotation.

Related: https://codeberg.org/freeipa/freeipa/issues/9920

## Summary by Sourcery

Mark DNSSEC-related integration tests as expected to fail when running on hosts with the problematic softhsm 2.7.0-0.1.rc1 version, centralizing the version check in a helper.

Tests:
- Add helper to detect the broken softhsm 2.7.0-0.1.rc1 package and use xfail_context around DNSSEC signing and key validation tests that fail with this version.
- Extend backup-and-restore DNSSEC zone test to conditionally xfail when the bad softhsm version is present to avoid spurious failures.