### PR TITLE
[Backport][ipa-4-13] Fix sshd_config permissions regression in ipa-client trigger

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1663,10 +1663,8 @@ if [ -f '/etc/ssh/sshd_config' -a $restore -ge 2 ]; then
     if [ -f '/etc/ssh/sshd_config.d/04-ipa.conf' ]; then
         if ! grep -E -q  '^\s*Include\s*/etc/ssh/sshd_config.d/\*\.conf' /etc/ssh/sshd_config 2> /dev/null ; then
             if ! grep -E -q '^\s*Include\s*/etc/ssh/sshd_config.d/04-ipa\.conf' /etc/ssh/sshd_config 2> /dev/null ; then
-                # Include the snippet
-                echo "Include /etc/ssh/sshd_config.d/04-ipa.conf" > /etc/ssh/sshd_config.ipanew
-                cat /etc/ssh/sshd_config >> /etc/ssh/sshd_config.ipanew
-                mv -fZ --backup=existing --suffix .ipaold /etc/ssh/sshd_config.ipanew /etc/ssh/sshd_config
+                # Fix for RHEL-210656: Ensure original permissions (0600) are preserved
+                sed --in-place=.ipaold '1i Include /etc/ssh/sshd_config.d/04-ipa.conf' /etc/ssh/sshd_config
             fi
         fi
     fi


### PR DESCRIPTION
This PR was opened automatically because PR #8485 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Bug Fixes:
- Restore correct sshd_config permissions handling in the ipa-client trigger on ipa-4-13.