### PR TITLE
[WIP] ipa trust-add: do not reuse ccache from  /run/ipa/krb5cc_oddjob_trusts

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/install/oddjob/com.redhat.idm.trust-fetch-domains.in
+++ b/install/oddjob/com.redhat.idm.trust-fetch-domains.in
@@ -219,25 +219,15 @@ with ipautil.private_krb5_config(trusted_domain, options.server) as cfg_file:
 
         try:
             have_ccache = False
-            try:
-                # The keytab may have stale key material (from older trust-add run)
-                cred = kinit_keytab(
-                    oneway_principal,
-                    oneway_keytab_name,
-                    oneway_ccache_name,
-                )
-                if cred.lifetime > 0:
-                    have_ccache = True
-            except (gssapi.exceptions.ExpiredCredentialsError, gssapi.raw.misc.GSSError):
-                pass
-            if not have_ccache:
-                if os.path.exists(oneway_ccache_name):
-                    os.unlink(oneway_ccache_name)
-                kinit_keytab(
-                    oneway_principal,
-                    oneway_keytab_name,
-                    oneway_ccache_name,
-                )
+            # The keytab may have stale key material (from older trust-add run)
+            # Always start from new cache
+            if os.path.exists(oneway_ccache_name):
+                os.unlink(oneway_ccache_name)
+            kinit_keytab(
+                oneway_principal,
+                oneway_keytab_name,
+                oneway_ccache_name,
+            )
         except (gssapi.exceptions.GSSError, gssapi.raw.misc.GSSError):
             # If there was failure on using keytab, assume it is stale and retrieve again
             retrieve_keytab(api, ccache_name, oneway_keytab_name, oneway_principal)

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,14 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_trust:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_trust.py::TestTrust
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *adroot_adchild_adtree_master_1client


### PR DESCRIPTION
With Windows 2025, the scenario trust-add / trust-del / trust-add is broken
because we try to re-use a previous ccache but fail to detect it is
stale.

Simplify the code and remove the ccache file if it exists.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10018

## Summary by Sourcery

Avoid reusing stale Kerberos ccaches in trust-add by removing any existing ccache file and extend CI to run AD trust integration tests on Fedora latest.

Bug Fixes:
- Prevent trust-add from reusing a stale Kerberos ccache from /run/ipa/krb5cc_oddjob_trusts, fixing broken trust-add / trust-del / trust-add workflows with newer Windows versions.

Tests:
- Replace the temporary Fedora latest CI job with an AD trust integration test job running test_integration/test_trust.py::TestTrust with a multi-domain AD topology.