### PR TITLE
ipa-adtrust-install: remove NetBIOS ports requirement from the text

### DIFF
--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -231,14 +231,10 @@ Setup complete
 You must make sure these network ports are open:
 \tTCP Ports:
 \t  * 135: epmap
-\t  * 138: netbios-dgm
-\t  * 139: netbios-ssn
 \t  * 445: microsoft-ds
 \t  * 1024..1300: epmap listener range
 \t  * 3268: msft-gc
 \tUDP Ports:
-\t  * 138: netbios-dgm
-\t  * 139: netbios-ssn
 \t  * 389: (C)LDAP
 \t  * 445: microsoft-ds
 

--- a/install/tools/man/ipa-adtrust-install.1
+++ b/install/tools/man/ipa-adtrust-install.1
@@ -44,10 +44,6 @@ the following ports to be open to allow IPA and Active Directory to communicate 
 .IP
 \(bu 135/tcp EPMAP
 .IP
-\(bu 138/tcp NetBIOS-DGM
-.IP
-\(bu 139/tcp NetBIOS-SSN
-.IP
 \(bu 445/tcp Microsoft-DS
 .IP
 \(bu 1024/tcp through 1300/tcp to allow EPMAP on port 135/tcp to create a TCP listener based
@@ -56,10 +52,6 @@ on an incoming request.
 \(bu 3268/tcp Microsoft-GC
 .TP
 \fBUDP Ports\fR
-.IP
-\(bu 138/udp NetBIOS-DGM
-.IP
-\(bu 139/udp NetBIOS-SSN
 .IP
 \(bu 389/udp LDAP
 


### PR DESCRIPTION
FreeIPA relies on Samba which forces use of SMB- and TCP-based transports, e.g. NCACN_NP, NCACN_IP_TCP. None of the NetBEUI-based transports is not supported, so we do not communicate over NetBIOS at all. However, DCE RPC protocol mapper mechanism allows to specify NetBIOS/NetBEUI for the communication. FreeIPA does not use any of those transports itself, so remove documented requirement to have those ports open.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10019

## Summary by Sourcery

Documentation:
- Remove NetBIOS TCP and UDP ports from the documented list of required open ports in ipa-adtrust-install manpage.