### PR TITLE
ipa-kdb: use client max_life as fallback in default kdcpolicy (RHEL-16280)

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -93,7 +93,11 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
     /* If no mechanisms are set, or it is anonymous PKINIT, allow every auth method */
     if ((ua == IPADB_USER_AUTH_NONE) ||
         (request->kdc_options & KDC_OPT_REQUEST_ANONYMOUS)) {
-        jitter(ONE_DAY_SECONDS, lifetime_out);
+	if (client->max_life > 0) {
+	    jitter(client->max_life, lifetime_out);
+	} else {
+	    jitter(ONE_DAY_SECONDS, lifetime_out);
+	}
         kerr = 0;
         goto done;
     }


### PR DESCRIPTION
When configuring extended Kerberos ticket lifetimes in FreeIPA (such as setting the global realm policy max_life to 30 days and requesting a 30-day ticket via kinit -l 30d or krb5.conf), the issued Ticket-Granting Ticket (TGT) is unconditionally capped at 24 hours(plus/minus jitter).

This issue is concentrated in the KDC policy plugin (daemons/ipa-kdb/ipa_kdb_kdcpolicy.c). Under ipa_kdcpolicy_check_as(), the default or anonymous authentication path (when no specific authentication indicators are present) unconditionally applies a 24-hour limit baseline via the hardcoded macro:
jitter(ONE_DAY_SECONDS, lifetime_out);
This forces all legacy, standard, or anonymous authentication flows to ignore the database-defined maximum ticket lifetimes, capping them strictly at 1 day.

Proposed Solution
This patch modifies the default authentication block inside ipa_kdcpolicy_check_as() to check if the client principal has a database-defined maximum lifetime limit (client->max_life > 0).

If configured, it applies client->max_life as the baseline.
If not, it falls back safely to the default ONE_DAY_SECONDS (24-hour) limit.
This matches the behavior already correctly implemented further down in the file for indicator-specific policies.

## Summary by Sourcery

Bug Fixes:
- Allow extended Kerberos ticket lifetimes by using the client principal max_life as the baseline instead of always capping tickets at one day in the default kdcpolicy path.