### PR TITLE
ipatests: Fixes for ds-migration testsuite

### DIFF
--- a/ipatests/test_integration/test_ds_migration.py
+++ b/ipatests/test_integration/test_ds_migration.py
@@ -12,6 +12,7 @@ import os
 import textwrap
 import time
 
+from ipaplatform.paths import paths
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 
@@ -58,6 +59,16 @@ def load_ldif_file(host, ldif_filename, dirman_password):
             "-f", remote_path,
         ]
     )
+
+
+def _remove_389ds_on_client(client):
+    """Remove the test 389-ds instance if it exists."""
+    instance_dir = paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % DS_INSTANCE_NAME
+    if client.transport.file_exists(instance_dir):
+        client.run_command(
+            [paths.DSCTL, DS_INSTANCE_NAME, "remove", "--do-it"],
+            raiseonerr=False,
+        )
 
 
 def _setup_389ds_on_client(client, admin_password):
@@ -149,6 +160,11 @@ class BaseTestDSMigration(IntegrationTest):
                 result.stdout_text + result.stderr_text
             ).lower()
         tasks.service_control_dirsrv(cls.master, "restart")
+
+    @classmethod
+    def uninstall(cls, mh):
+        _remove_389ds_on_client(cls.clients[0])
+        super(BaseTestDSMigration, cls).uninstall(mh)
 
     def kerberos_keys_available(self, uid):
         """Return True if Kerberos keys are available for *uid*."""


### PR DESCRIPTION
ds-migration testsuite is failing with the below error for ds-migration tests in class TestDSMigrationOptions.
 'subprocess.CalledProcessError: Command '['dscreate', 'from-file', '/tmp/ds-instance.inf']' returned non-zero exit status 1.'
 This patch adds a cleanup for removing the instance i.e _remove_389ds_on_client

https://codeberg.org/freeipa/freeipa/issues/10029

## Summary by Sourcery

Ensure ds-migration integration tests cleanly manage 389-DS instances and are exercised in CI.

CI:
- Wire the temporary PR CI job to run the ds-migration integration test suite instead of a placeholder test file.

Tests:
- Add cleanup of existing 389-DS instances in ds-migration integration tests to prevent setup failures.
- Invoke ds-migration integration test suite in the temporary PR CI definition.