### PR TITLE
Spec file: bump samba version

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -104,9 +104,9 @@
 # Require 4.7.0 which brings Python 3 bindings
 # Require 4.12 which has DsRGetForestTrustInformation access rights fixes
 %if 0%{?fedora} < 44
-%global samba_version 2:4.23.8
+%global samba_version 2:4.23.10
 %else
-%global samba_version 2:4.24.3
+%global samba_version 2:4.24.5
 %endif
 
 # 3.14.5-45 or later includes a number of interfaces fixes for IPA interface


### PR DESCRIPTION
Samba has been updated in fedora:
- fedora 43: samba-4.23.10-1.fc43
- fedora 44: samba-4.24.5-1.fc44
- fedora 45: samba-4.24.5-1.fc45

## Summary by Sourcery

Align FreeIPA RPM spec Samba version requirements with the updated Samba packages in recent Fedora releases.

Enhancements:
- Update Samba dependency versions in the FreeIPA spec file to match current Fedora releases.

Build:
- Adjust RPM spec to require newer Samba package versions for Fedora 43, 44, and 45.