### PR TITLE
ipa-migrate: require Replication Administrator privilege

### DIFF
--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -30,6 +30,8 @@ from ipalib import api, errors, output
 from ipalib import Command, Password, Str, Flag, StrEnum, DNParam, Bool
 from ipalib.cli import to_cli
 from ipalib.plugable import Registry
+from ipalib.request import context
+from ipaserver.plugins.privilege import principal_has_privilege
 from ipaserver.plugins.user import NO_UPG_MAGIC
 from ipalib import _
 from ipapython.dn import DN
@@ -903,6 +905,12 @@ migration process might be incomplete\n''')
         # check if migration mode is enabled
         if not config.get('ipamigrationenabled', (False,))[0]:
             return dict(result={}, failed={}, enabled=False, compat=True)
+
+        privilege = 'Replication Administrators'
+        op_account = getattr(context, 'principal', None)
+        if not principal_has_privilege(self.api, op_account, privilege):
+            raise errors.ACIError(
+                info=_("not allowed to run migration"))
 
         # connect to DS
         if options.get('cacertfile') is not None:

--- a/ipatests/test_integration/test_ds_migration.py
+++ b/ipatests/test_integration/test_ds_migration.py
@@ -683,6 +683,68 @@ class TestDSMigrationConfig(BaseTestDSMigration):
         finally:
             self.cleanup_migrated_data()
 
+    def test_privilege(self):
+        """ Test that an unprivileged user can't run migrate-ds"""
+        user = 'migrationuser'
+        password = 'Secret123'
+
+        # Create an unprivileged user who will perform migration
+        # Should fail
+        tasks.create_active_user(self.master, user, password)
+        try:
+            tasks.kdestroy_all(self.master)
+            tasks.kinit_as_user(self.master, user, password)
+            result = self.master.run_command(
+                [
+                    "ipa",
+                    "migrate-ds",
+                    "--user-container=ou=People",
+                    "--group-container=ou=Groups",
+                    self.ldap_uri,
+                ],
+                stdin_text=self.master.config.admin_password,
+                raiseonerr=False
+            )
+            assert "not allowed to run migration" in result.stderr_text
+
+            # Now add the "Security Architect" role to this user
+            # (which grants Replication Administrators privilege)
+            # and "User Administrator" role (which allows to write users)
+            # and retry migrate-ds.
+            # Should succeed
+            tasks.kinit_admin(self.master)
+            self.master.run_command(
+                [
+                    "ipa",
+                    "role-add-member",
+                    "User Administrator",
+                    "--user", user
+                ]
+            )
+            self.master.run_command(
+                [
+                    "ipa",
+                    "role-add-member",
+                    "Security Architect",
+                    "--user", user
+                ]
+            )
+            tasks.kdestroy_all(self.master)
+            tasks.kinit_as_user(self.master, user, password)
+            result = self.master.run_command(
+                [
+                    "ipa",
+                    "migrate-ds",
+                    "--user-container=ou=People",
+                    "--group-container=ou=Groups",
+                    self.ldap_uri,
+                ],
+                stdin_text=self.master.config.admin_password,
+            )
+
+        finally:
+            self.cleanup_migrated_data()
+
 
 class TestDSMigrationOptions(BaseTestDSMigration):
     """


### PR DESCRIPTION
Check that the authenticated user has the "Replication Administrator"
privilege before connecting to the remote LDAP server.
The privilege is granted to members of the admins group by default.
Note that the user also needs write access to groups and users.

Add a corresponding test.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10026
Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>

## Summary by Sourcery

Enforce that ipa migrate-ds can only be run by principals with the Replication Administrators privilege and extend integration and CI coverage for DS migration behavior.

New Features:
- Add a privilege check ensuring the migrate-ds command requires the Replication Administrators privilege before connecting to the remote LDAP server.

Bug Fixes:
- Prevent unprivileged users from running migrate-ds, addressing the missing authorization check reported in issue 10026.

Enhancements:
- Add an integration test verifying migrate-ds fails for an unprivileged user and succeeds once appropriate roles granting replication and user administration privileges are assigned.
- Adjust PR CI configuration to run the DS migration integration test suite on Fedora with an increased timeout and appropriate topology.