### PR TITLE
host-mod: also guard userpassword when delivered via --setattr

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -929,7 +929,11 @@ class host_mod(LDAPUpdate):
         fqdn = resolve_fqdn(keys[-1])
         # Allow an existing OTP to be reset but don't allow a OTP to be
         # added to an enrolled host.
-        if options.get('userpassword') or options.get('random'):
+        if (
+            options.get('userpassword')
+            or options.get('random')
+            or entry_attrs.get('userpassword')
+        ):
             entry = {}
             self.obj.get_password_attributes(ldap, dn, entry)
             if not entry['has_password'] and entry['has_keytab']:

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -752,6 +752,11 @@ class TestHostFalsePwdChange(XMLRPC_test):
         with pytest.raises(errors.ValidationError):
             command()
 
+        # Try to change the pwd of enrolled host with --setattr userpassword
+        command = host.make_update_command(updates=dict(
+            setattr=u'userpassword=pass_123'))
+        with pytest.raises(errors.ValidationError):
+            command()
 
 @pytest.fixture(scope='class')
 def dns_setup_nonameserver(host4):


### PR DESCRIPTION
host_mod.pre_callback refused to set a one-time password on an already-enrolled host, but only when the value arrived via the dedicated --password/--random options. The same value delivered via `--setattr userpassword=...` reached entry_attrs without tripping the guard, letting a Modify-Hosts holder re-enroll an enrolled host.

Check entry_attrs as well as options.

Add a corresponding test.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10027

## Summary by Sourcery

Guard host one-time password changes delivered via both dedicated options and userpassword setattr for already-enrolled hosts, and add a regression test covering the setattr case.

Bug Fixes:
- Prevent re-enrollment of already-enrolled hosts by blocking userpassword changes provided via --setattr as well as via password/random options.

Tests:
- Add XMLRPC host plugin test ensuring password changes on enrolled hosts via --setattr userpassword are rejected with a validation error.