### PR TITLE
ipa env: support only simple * wildcard

### DIFF
--- a/ipalib/misc.py
+++ b/ipalib/misc.py
@@ -3,7 +3,7 @@
 #
 
 import re
-from ipalib import LocalOrRemote, _, ngettext
+from ipalib import LocalOrRemote, _, ngettext, errors
 from ipalib.output import Output, summary
 from ipalib import Flag
 from ipalib.plugable import Registry
@@ -60,7 +60,15 @@ class env(LocalOrRemote):
 
     def __find_keys(self, variables):
         keys = set()
+        # ipa env VARIABLES support wildcard * but we should prevent
+        # any other regex
+        pattern = re.compile(r'^[\w*]*$')
         for query in variables:
+            if not pattern.match(query):
+                raise errors.ValidationError(
+                    name='variables',
+                    error='Variables support only unicode word characters or *'
+                )
             if '*' in query:
                 pat = re.compile(query.replace('*', '.*') + '$')
                 for key in self.env:

--- a/ipatests/test_xmlrpc/test_env_plugin.py
+++ b/ipatests/test_xmlrpc/test_env_plugin.py
@@ -99,3 +99,15 @@ class TestEnv(XMLRPC_test):
         with pytest.raises(errors.OptionError) as e:
             self.run_env(nonexistentoption="nonexistentoption", server=server)
         assert "Unknown option: nonexistentoption" in str(e.value)
+
+    @pytest.mark.parametrize("server", [True, False], ids=["server", "local"])
+    def test_env_with_bad_filter(self, server):
+        with pytest.raises(errors.ValidationError) as e:
+            self.run_env("ldap+cache", server=server)
+        msg = "Variables support only unicode word characters or *"
+        assert msg in str(e.value)
+
+    @pytest.mark.parametrize("server", [True, False], ids=["server", "local"])
+    def test_env_with_good_filter(self, server):
+        cmd_result = self.run_env("ldap_cache*", server=server)
+        self.assert_result(cmd_result)


### PR DESCRIPTION
ipa env returns the list of all env variables, but can also be called with a given variable name or a name containing a wildcard. Limit the wildcards to simple shell-style wildcard with *, for instance ipa env ldap_cache_* would return the values ldap_cache_debug and ldap_cache_size.

This avoids the processing of complex regexp and is acceptable because the environment variables have names containing only word characters like [a-zA-Z0-9_].

Add a corresponding test

Fixes: https://codeberg.org/freeipa/freeipa/issues/10028

## Summary by Sourcery

Restrict ipa env variable name filtering to simple * wildcards and add tests for valid and invalid filters.

Bug Fixes:
- Reject env variable filters containing non-word characters to avoid processing complex regular expressions.

Tests:
- Add XML-RPC tests covering invalid env filters with non-word characters and valid filters using * wildcards.