### PR TITLE
ipa-epn: fix transposed uid/gid and fail closed on  drop_privileges()

### DIFF
--- a/ipaclient/install/ipa_epn.py
+++ b/ipaclient/install/ipa_epn.py
@@ -118,11 +118,11 @@ def drop_privileges(new_username="daemon", new_groupname="daemon"):
             return
 
         os.setgroups([])
-        os.setgid(pwd.getpwnam(new_username).pw_uid)
-        os.setuid(grp.getgrnam(new_groupname).gr_gid)
+        os.setgid(grp.getgrnam(new_groupname).gr_gid)
+        os.setuid(pwd.getpwnam(new_username).pw_uid)
 
         if os.getuid() == 0:
-            raise errors.RequiresRoot("Cannot drop privileges!")
+            raise RuntimeError("still uid 0 after setuid()")
 
         logger.debug(
             "Dropped privileges to user=%s, group=%s",
@@ -131,11 +131,11 @@ def drop_privileges(new_username="daemon", new_groupname="daemon"):
         )
 
     except Exception as e:
-        logger.error(
-            "Failed to drop privileges to %s, %s: %s",
-            new_username,
-            new_groupname,
-            e,
+        # Fail closed: do NOT continue as root.
+        raise admintool.ScriptError(
+            "Failed to drop privileges to %s, %s: %s" % (
+                new_username, new_groupname, e,
+            )
         )
 
 

--- a/ipatests/test_ipaclient/test_epn.py
+++ b/ipatests/test_ipaclient/test_epn.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+
+import pytest
+import ipatests.util
+
+ipatests.util.check_ipaclient_unittests()
+
+from ipaclient.install.ipa_epn import drop_privileges
+from ipapython import admintool
+
+
+@pytest.mark.parametrize(
+    "user,group", [
+        ("unknown_user", "daemon"),
+        ("daemon", "unknown_group"),
+        ("unknown_user", "unknown_group")])
+def test_drop_privileges(user, group):
+    """ Test the drop_privileges method with unknown uid/gid"""
+    try:
+        drop_privileges(user, group)
+    except admintool.ScriptError:
+        # Raised error as expected
+        pass
+    else:
+        assert False


### PR DESCRIPTION
drop_privileges() passed pw_uid to setgid() and gr_gid to setuid(), and
swallowed any exception so the notifier continued as root when the drop
failed.

Pass the right ids to the right syscalls, and abort on failure.

Add a unit test for the drop_privileges method

Fixes: https://codeberg.org/freeipa/freeipa/issues/10030

## Summary by Sourcery

Fix privilege dropping in ipa-epn to use correct user/group IDs and fail closed when dropping privileges fails.

Bug Fixes:
- Correct the use of user and group IDs when calling setuid and setgid in drop_privileges so privileges are actually reduced.
- Ensure drop_privileges aborts execution by raising a ScriptError instead of continuing as root when privilege dropping fails.

Tests:
- Add a unit test verifying that drop_privileges raises a ScriptError when given unknown user and/or group names.
- Add a dedicated CI job to run the ipa-epn integration test suite with updated topology and timeout.