### PR TITLE
ipa-otptoken-import: request a MAC if a MAC method is specified

### DIFF
--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -262,8 +262,12 @@ class XMLDecryptor:
         if len(self.__key) * 8 != klen:
             raise ValidationError("Invalid key length!")
 
-        # If a MAC is present, perform validation.
-        if mac:
+        if self.__hmac is not None:
+            # The document declared <MACMethod>; per RFC 6030 §6.1.1 every
+            # encrypted value MUST carry a ValueMAC. Refuse a stripped one.
+            if not mac:
+                raise ValidationError(
+                    "MACMethod declared but <ValueMAC> missing on key")
             tmp = self.__hmac.copy()
             tmp.update(data)
             try:

--- a/ipatests/test_ipaserver/data/pskc-missingmac.xml
+++ b/ipatests/test_ipaserver/data/pskc-missingmac.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<KeyContainer Version="1.0"
+    xmlns="urn:ietf:params:xml:ns:keyprov:pskc"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
+    <EncryptionKey>
+        <ds:KeyName>Pre-shared-key</ds:KeyName>
+    </EncryptionKey>
+    <MACMethod Algorithm="http://www.w3.org/2000/09/xmldsig#hmac-sha1">
+        <MACKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>ESIzRFVmd4iZABEiM0RVZgKn6WjLaTC1sbeBMSvIhRejN9vJa2BOlSaMrR7I5wSX</xenc:CipherValue>
+            </xenc:CipherData>
+        </MACKey>
+    </MACMethod>
+    <KeyPackage>
+        <DeviceInfo>
+            <Manufacturer>Manufacturer</Manufacturer>
+            <SerialNo>987654321</SerialNo>
+        </DeviceInfo>
+        <CryptoModuleInfo>
+            <Id>CM_ID_001</Id>
+        </CryptoModuleInfo>
+        <Key Id="MissingMAC"
+            Algorithm="urn:ietf:params:xml:ns:keyprov:pskc:hotp">
+            <Issuer>Issuer</Issuer>
+            <AlgorithmParameters>
+                <ResponseFormat Length="8" Encoding="DECIMAL"/>
+            </AlgorithmParameters>
+            <Data>
+                <Secret>
+                    <EncryptedValue>
+                        <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+                        <xenc:CipherData>
+                            <xenc:CipherValue>AAECAwQFBgcICQoLDA0OD+cIHItlB3Wra1DUpxVvOx2lef1VmNPCMl8jwZqIUqGv</xenc:CipherValue>
+                        </xenc:CipherData>
+                    </EncryptedValue>
+                </Secret>
+                <Counter>
+                    <PlainValue>0</PlainValue>
+                </Counter>
+            </Data>
+        </Key>
+    </KeyPackage>
+</KeyContainer>

--- a/ipatests/test_ipaserver/test_otptoken_import.py
+++ b/ipatests/test_ipaserver/test_otptoken_import.py
@@ -112,6 +112,16 @@ class test_otptoken_import:
         else:
             assert False
 
+    def test_missingmac(self):
+        doc = PSKCDocument(os.path.join(basename, "pskc-missingmac.xml"))
+        doc.setKey(codecs.decode('12345678901234567890123456789012', 'hex'))
+        try:
+            [(t.id, t.options) for t in doc.getKeyPackages()]
+        except ValidationError as e:  # <ValueMAC> missing on key
+            assert str(e) == "MACMethod declared but <ValueMAC> missing on key"
+        else:
+            assert False
+
     def test_full(self):
         doc = PSKCDocument(os.path.join(basename, "full.xml"))
         assert [(t.id, t.options) for t in doc.getKeyPackages()] == \


### PR DESCRIPTION
When importing OTP tokens, per RFC 6030 §6.1.1 every encrypted value must carry a ValueMAC.
If the PSKC file defines a MACMethod, refuse to import a key which does not have a ValueMAC.

Add a corresponding test.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10031

## Summary by Sourcery

Enforce RFC 6030 MAC requirements when importing PSKC OTP tokens by rejecting keys that declare a MACMethod but omit a ValueMAC, and add coverage for this scenario.

Bug Fixes:
- Prevent importing OTP keys from PSKC documents that define a MACMethod but lack a corresponding ValueMAC, aligning validation with RFC 6030.

Tests:
- Add a PSKC fixture and test case to verify that missing ValueMAC triggers a validation error when MACMethod is declared.