### PR TITLE
[Backport][ipa-4-13] ipa-otptoken-import: harden lxml parser against XXE

### DIFF
--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -53,6 +53,12 @@ from ipaserver.plugins.ldap2 import AUTOBIND_DISABLED
 
 logger = logging.getLogger(__name__)
 
+SAFE_XML_PARSER = etree.XMLParser(
+    resolve_entities=False,
+    no_network=True,
+    load_dtd=False,
+    dtd_validation=False,
+)
 
 class ValidationError(Exception):
     pass
@@ -472,7 +478,7 @@ class PSKCDocument:
     def __init__(self, filename):
         self.__keyname = None
         self.__decryptor = None
-        self.__doc = etree.parse(filename)
+        self.__doc = etree.parse(filename, parser=SAFE_XML_PARSER)
         self.__mkey = fetch(self.__doc, "./pskc:MACMethod/pskc:MACKey")
         self.__algo = fetch(self.__doc, "./pskc:MACMethod/@Algorithm", convertHMACType)
 

--- a/ipatests/test_ipaserver/data/pskc-entity.xml
+++ b/ipatests/test_ipaserver/data/pskc-entity.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE KeyContainer [
+  <!ENTITY xxe SYSTEM "file:///etc/hosts">
+]>
+<KeyContainer Version="1.0" xmlns="urn:ietf:params:xml:ns:keyprov:pskc">
+ <KeyPackage>
+  <DeviceInfo><Manufacturer>&xxe;</Manufacturer><SerialNo>1</SerialNo></DeviceInfo>
+  <Key Id="Entity1" Algorithm="urn:ietf:params:xml:ns:keyprov:pskc:hotp">
+   <Issuer>&xxe;</Issuer>
+   <AlgorithmParameters><ResponseFormat Length="6" Encoding="DECIMAL"/></AlgorithmParameters>
+   <Data><Secret><PlainValue>MTIzNDU2Nzg5MDEyMzQ1Njc4OTA=</PlainValue></Secret>
+         <Counter><PlainValue>0</PlainValue></Counter></Data>
+  </Key>
+ </KeyPackage>
+</KeyContainer>

--- a/ipatests/test_ipaserver/test_otptoken_import.py
+++ b/ipatests/test_ipaserver/test_otptoken_import.py
@@ -148,3 +148,15 @@ class test_otptoken_import:
         assert convertHashName('something-sha256') == u'sha1'
         assert convertHashName('') == u'sha1'
         assert convertHashName(None) == u'sha1'
+
+    def test_entity(self):
+        doc = PSKCDocument(os.path.join(basename, "pskc-entity.xml"))
+        # Make sure ipatokenvendor is not filled with local file content
+        assert [(t.id, t.options) for t in doc.getKeyPackages()] == \
+            [(u'Entity1', {
+                'ipatokenotpkey': u'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ',
+                'type': u'hotp',
+                'ipatokenserial': u'1',
+                'ipatokenhotpcounter': 0,
+                'ipatokenotpdigits': 6,
+            })]


### PR DESCRIPTION
This PR was opened automatically because PR #8515 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Harden PSKC XML parsing against external entity and DTD-based XXE attacks and add regression coverage.

Bug Fixes:
- Prevent XML external entity (XXE) resolution when importing PSKC OTP tokens to avoid loading local file content into token metadata.

Tests:
- Add PSKC XML fixture with an external entity and a test ensuring token options are not populated from local file content during import.