### PR TITLE
[Backport][ipa-4-13] host-mod: also guard userpassword when delivered via --setattr

### DIFF
--- a/ipaserver/plugins/host.py
+++ b/ipaserver/plugins/host.py
@@ -929,7 +929,11 @@ class host_mod(LDAPUpdate):
         fqdn = resolve_fqdn(keys[-1])
         # Allow an existing OTP to be reset but don't allow a OTP to be
         # added to an enrolled host.
-        if options.get('userpassword') or options.get('random'):
+        if (
+            options.get('userpassword')
+            or options.get('random')
+            or entry_attrs.get('userpassword')
+        ):
             entry = {}
             self.obj.get_password_attributes(ldap, dn, entry)
             if not entry['has_password'] and entry['has_keytab']:

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -752,6 +752,11 @@ class TestHostFalsePwdChange(XMLRPC_test):
         with pytest.raises(errors.ValidationError):
             command()
 
+        # Try to change the pwd of enrolled host with --setattr userpassword
+        command = host.make_update_command(updates=dict(
+            setattr=u'userpassword=pass_123'))
+        with pytest.raises(errors.ValidationError):
+            command()
 
 @pytest.fixture(scope='class')
 def dns_setup_nonameserver(host4):


### PR DESCRIPTION
This PR was opened automatically because PR #8519 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Guard host password changes delivered via host-mod --setattr for enrolled hosts and add corresponding regression coverage.

Bug Fixes:
- Prevent userpassword from being set via host-mod --setattr on enrolled hosts that already have keytabs but no existing password.

Tests:
- Add XML-RPC host plugin test ensuring userpassword changes via --setattr are rejected for enrolled hosts.