### PR TITLE
[Backport][ipa-4-13] ipa env: support only simple * wildcard

### DIFF
--- a/ipalib/misc.py
+++ b/ipalib/misc.py
@@ -3,7 +3,7 @@
 #
 
 import re
-from ipalib import LocalOrRemote, _, ngettext
+from ipalib import LocalOrRemote, _, ngettext, errors
 from ipalib.output import Output, summary
 from ipalib import Flag
 from ipalib.plugable import Registry
@@ -60,7 +60,15 @@ class env(LocalOrRemote):
 
     def __find_keys(self, variables):
         keys = set()
+        # ipa env VARIABLES support wildcard * but we should prevent
+        # any other regex
+        pattern = re.compile(r'^[\w*]*$')
         for query in variables:
+            if not pattern.match(query):
+                raise errors.ValidationError(
+                    name='variables',
+                    error='Variables support only unicode word characters or *'
+                )
             if '*' in query:
                 pat = re.compile(query.replace('*', '.*') + '$')
                 for key in self.env:

--- a/ipatests/test_xmlrpc/test_env_plugin.py
+++ b/ipatests/test_xmlrpc/test_env_plugin.py
@@ -99,3 +99,15 @@ class TestEnv(XMLRPC_test):
         with pytest.raises(errors.OptionError) as e:
             self.run_env(nonexistentoption="nonexistentoption", server=server)
         assert "Unknown option: nonexistentoption" in str(e.value)
+
+    @pytest.mark.parametrize("server", [True, False], ids=["server", "local"])
+    def test_env_with_bad_filter(self, server):
+        with pytest.raises(errors.ValidationError) as e:
+            self.run_env("ldap+cache", server=server)
+        msg = "Variables support only unicode word characters or *"
+        assert msg in str(e.value)
+
+    @pytest.mark.parametrize("server", [True, False], ids=["server", "local"])
+    def test_env_with_good_filter(self, server):
+        cmd_result = self.run_env("ldap_cache*", server=server)
+        self.assert_result(cmd_result)


### PR DESCRIPTION
This PR was opened automatically because PR #8520 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Validate ipa env variables to only allow simple * wildcard patterns and add tests covering accepted and rejected filters.

Bug Fixes:
- Reject ipa env variable filters that contain characters other than unicode word characters and *.

Tests:
- Add XML-RPC env plugin tests to verify bad filters are rejected and valid wildcard filters succeed.