### PR TITLE
[Backport][ipa-4-13] ipa-otptoken-import: request a MAC if a MAC method is specified

### DIFF
--- a/ipaserver/install/ipa_otptoken_import.py
+++ b/ipaserver/install/ipa_otptoken_import.py
@@ -268,8 +268,12 @@ class XMLDecryptor:
         if len(self.__key) * 8 != klen:
             raise ValidationError("Invalid key length!")
 
-        # If a MAC is present, perform validation.
-        if mac:
+        if self.__hmac is not None:
+            # The document declared <MACMethod>; per RFC 6030 §6.1.1 every
+            # encrypted value MUST carry a ValueMAC. Refuse a stripped one.
+            if not mac:
+                raise ValidationError(
+                    "MACMethod declared but <ValueMAC> missing on key")
             tmp = self.__hmac.copy()
             tmp.update(data)
             try:

--- a/ipatests/test_ipaserver/data/pskc-missingmac.xml
+++ b/ipatests/test_ipaserver/data/pskc-missingmac.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<KeyContainer Version="1.0"
+    xmlns="urn:ietf:params:xml:ns:keyprov:pskc"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
+    <EncryptionKey>
+        <ds:KeyName>Pre-shared-key</ds:KeyName>
+    </EncryptionKey>
+    <MACMethod Algorithm="http://www.w3.org/2000/09/xmldsig#hmac-sha1">
+        <MACKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>ESIzRFVmd4iZABEiM0RVZgKn6WjLaTC1sbeBMSvIhRejN9vJa2BOlSaMrR7I5wSX</xenc:CipherValue>
+            </xenc:CipherData>
+        </MACKey>
+    </MACMethod>
+    <KeyPackage>
+        <DeviceInfo>
+            <Manufacturer>Manufacturer</Manufacturer>
+            <SerialNo>987654321</SerialNo>
+        </DeviceInfo>
+        <CryptoModuleInfo>
+            <Id>CM_ID_001</Id>
+        </CryptoModuleInfo>
+        <Key Id="MissingMAC"
+            Algorithm="urn:ietf:params:xml:ns:keyprov:pskc:hotp">
+            <Issuer>Issuer</Issuer>
+            <AlgorithmParameters>
+                <ResponseFormat Length="8" Encoding="DECIMAL"/>
+            </AlgorithmParameters>
+            <Data>
+                <Secret>
+                    <EncryptedValue>
+                        <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+                        <xenc:CipherData>
+                            <xenc:CipherValue>AAECAwQFBgcICQoLDA0OD+cIHItlB3Wra1DUpxVvOx2lef1VmNPCMl8jwZqIUqGv</xenc:CipherValue>
+                        </xenc:CipherData>
+                    </EncryptedValue>
+                </Secret>
+                <Counter>
+                    <PlainValue>0</PlainValue>
+                </Counter>
+            </Data>
+        </Key>
+    </KeyPackage>
+</KeyContainer>

--- a/ipatests/test_ipaserver/test_otptoken_import.py
+++ b/ipatests/test_ipaserver/test_otptoken_import.py
@@ -112,6 +112,16 @@ class test_otptoken_import:
         else:
             assert False
 
+    def test_missingmac(self):
+        doc = PSKCDocument(os.path.join(basename, "pskc-missingmac.xml"))
+        doc.setKey(codecs.decode('12345678901234567890123456789012', 'hex'))
+        try:
+            [(t.id, t.options) for t in doc.getKeyPackages()]
+        except ValidationError as e:  # <ValueMAC> missing on key
+            assert str(e) == "MACMethod declared but <ValueMAC> missing on key"
+        else:
+            assert False
+
     def test_full(self):
         doc = PSKCDocument(os.path.join(basename, "full.xml"))
         assert [(t.id, t.options) for t in doc.getKeyPackages()] == \


### PR DESCRIPTION
This PR was opened automatically because PR #8522 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Enforce MAC presence for encrypted PSKC values when a MAC method is declared and add coverage for missing MAC scenarios.

Bug Fixes:
- Reject PSKC key packages that declare a MAC method but omit the corresponding ValueMAC on the key.

Tests:
- Add PSKC fixture and unit test to verify that importing a token with a declared MAC method but missing ValueMAC fails with a specific validation error.