### PR TITLE
[Backport][ipa-4-13] ipa-epn: fix transposed uid/gid and fail closed on  drop_privileges()

### DIFF
--- a/ipaclient/install/ipa_epn.py
+++ b/ipaclient/install/ipa_epn.py
@@ -83,11 +83,11 @@ def drop_privileges(new_username="daemon", new_groupname="daemon"):
             return
 
         os.setgroups([])
-        os.setgid(pwd.getpwnam(new_username).pw_uid)
-        os.setuid(grp.getgrnam(new_groupname).gr_gid)
+        os.setgid(grp.getgrnam(new_groupname).gr_gid)
+        os.setuid(pwd.getpwnam(new_username).pw_uid)
 
         if os.getuid() == 0:
-            raise errors.RequiresRoot("Cannot drop privileges!")
+            raise RuntimeError("still uid 0 after setuid()")
 
         logger.debug(
             "Dropped privileges to user=%s, group=%s",
@@ -96,11 +96,11 @@ def drop_privileges(new_username="daemon", new_groupname="daemon"):
         )
 
     except Exception as e:
-        logger.error(
-            "Failed to drop privileges to %s, %s: %s",
-            new_username,
-            new_groupname,
-            e,
+        # Fail closed: do NOT continue as root.
+        raise admintool.ScriptError(
+            "Failed to drop privileges to %s, %s: %s" % (
+                new_username, new_groupname, e,
+            )
         )
 
 

--- a/ipatests/test_ipaclient/test_epn.py
+++ b/ipatests/test_ipaclient/test_epn.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+
+import pytest
+import ipatests.util
+
+ipatests.util.check_ipaclient_unittests()
+
+from ipaclient.install.ipa_epn import drop_privileges
+from ipapython import admintool
+
+
+@pytest.mark.parametrize(
+    "user,group", [
+        ("unknown_user", "daemon"),
+        ("daemon", "unknown_group"),
+        ("unknown_user", "unknown_group")])
+def test_drop_privileges(user, group):
+    """ Test the drop_privileges method with unknown uid/gid"""
+    try:
+        drop_privileges(user, group)
+    except admintool.ScriptError:
+        # Raised error as expected
+        pass
+    else:
+        assert False


### PR DESCRIPTION
This PR was opened automatically because PR #8521 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Correct drop_privileges behavior in ipa-epn to avoid running as root when privilege dropping fails.

Bug Fixes:
- Fix transposed uid/gid arguments when setting process user and group in drop_privileges.
- Ensure the script fails closed by raising an error instead of continuing execution if privilege dropping fails or still runs as uid 0.

Tests:
- Add unit tests for drop_privileges to verify it raises ScriptError when given unknown user or group.