### PR TITLE
[Backport][ipa-4-13] ipa-migrate: require Replication Administrator privilege

### DIFF
--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -30,6 +30,8 @@ from ipalib import api, errors, output
 from ipalib import Command, Password, Str, Flag, StrEnum, DNParam, Bool
 from ipalib.cli import to_cli
 from ipalib.plugable import Registry
+from ipalib.request import context
+from ipaserver.plugins.privilege import principal_has_privilege
 from ipaserver.plugins.user import NO_UPG_MAGIC
 from ipalib import _
 from ipapython.dn import DN
@@ -903,6 +905,12 @@ migration process might be incomplete\n''')
         # check if migration mode is enabled
         if not config.get('ipamigrationenabled', (False,))[0]:
             return dict(result={}, failed={}, enabled=False, compat=True)
+
+        privilege = 'Replication Administrators'
+        op_account = getattr(context, 'principal', None)
+        if not principal_has_privilege(self.api, op_account, privilege):
+            raise errors.ACIError(
+                info=_("not allowed to run migration"))
 
         # connect to DS
         if options.get('cacertfile') is not None:

--- a/ipatests/test_integration/test_ds_migration.py
+++ b/ipatests/test_integration/test_ds_migration.py
@@ -683,6 +683,68 @@ class TestDSMigrationConfig(BaseTestDSMigration):
         finally:
             self.cleanup_migrated_data()
 
+    def test_privilege(self):
+        """ Test that an unprivileged user can't run migrate-ds"""
+        user = 'migrationuser'
+        password = 'Secret123'
+
+        # Create an unprivileged user who will perform migration
+        # Should fail
+        tasks.create_active_user(self.master, user, password)
+        try:
+            tasks.kdestroy_all(self.master)
+            tasks.kinit_as_user(self.master, user, password)
+            result = self.master.run_command(
+                [
+                    "ipa",
+                    "migrate-ds",
+                    "--user-container=ou=People",
+                    "--group-container=ou=Groups",
+                    self.ldap_uri,
+                ],
+                stdin_text=self.master.config.admin_password,
+                raiseonerr=False
+            )
+            assert "not allowed to run migration" in result.stderr_text
+
+            # Now add the "Security Architect" role to this user
+            # (which grants Replication Administrators privilege)
+            # and "User Administrator" role (which allows to write users)
+            # and retry migrate-ds.
+            # Should succeed
+            tasks.kinit_admin(self.master)
+            self.master.run_command(
+                [
+                    "ipa",
+                    "role-add-member",
+                    "User Administrator",
+                    "--user", user
+                ]
+            )
+            self.master.run_command(
+                [
+                    "ipa",
+                    "role-add-member",
+                    "Security Architect",
+                    "--user", user
+                ]
+            )
+            tasks.kdestroy_all(self.master)
+            tasks.kinit_as_user(self.master, user, password)
+            result = self.master.run_command(
+                [
+                    "ipa",
+                    "migrate-ds",
+                    "--user-container=ou=People",
+                    "--group-container=ou=Groups",
+                    self.ldap_uri,
+                ],
+                stdin_text=self.master.config.admin_password,
+            )
+
+        finally:
+            self.cleanup_migrated_data()
+
 
 class TestDSMigrationOptions(BaseTestDSMigration):
     """


### PR DESCRIPTION
This PR was opened automatically because PR #8518 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Require Replication Administrators privilege to run the IPA migrate-ds operation and validate this behavior in integration tests.

New Features:
- Restrict migrate-ds execution to accounts with the Replication Administrators privilege.

Tests:
- Add integration test ensuring migrate-ds fails for unprivileged users and succeeds once appropriate roles granting Replication Administrators privilege are assigned.