### PR TITLE
ipa-kdb: prefer the longest matching trusted domain name

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac.c
@@ -3271,101 +3271,164 @@ krb5_error_code ipadb_check_transited_realms(krb5_context kcontext,
 	return ret;
 }
 
-/* Checks whether a principal's realm is one of trusted domains' realm or NetBIOS name
- * and returns the realm of the matched trusted domain in 'trusted_domain'
- * Returns 0 in case of success and KRB5_KDB_NOENTRY otherwise
- * If DAL driver is not initialized, returns KRB5_KDB_DBNOTINITED */
-krb5_error_code ipadb_is_princ_from_trusted_realm(krb5_context kcontext,
-						  const char *test_realm, size_t size,
-						  char **trusted_realm)
+/*
+ * How much of test_realm one of the names of a trusted domain matches.
+ * trust_name is that domain's Kerberos realm, its NetBIOS name or one of its
+ * UPN suffixes. test_realm is not necessarily NUL terminated, so its length is
+ * size and not strlen().
+ *
+ * Returns size when the two names are equal, that is when trust_name matches
+ * all of test_realm. Returns trust_name_len when test_realm is subordinate to
+ * trust_name, that is when it ends with trust_name at a dot boundary; this
+ * requires trust_name_len < size, so size is the largest result possible.
+ * Returns 0 when neither applies.
+ */
+static size_t
+ipadb_trust_name_match_len(const char *test_realm, size_t size,
+                           const char *trust_name, size_t trust_name_len)
 {
-	struct ipadb_context *ipactx;
-	size_t i, j, length;
-	const char *name;
-	bool result = false;
+    if (size == trust_name_len) {
+        return (strncasecmp(test_realm, trust_name, size) == 0)
+               ? trust_name_len : 0;
+    }
 
-	if (test_realm == NULL || test_realm[0] == '\0') {
-		return KRB5_KDB_NOENTRY;
-	}
+    if ((size > trust_name_len)
+        && (test_realm[size - trust_name_len - 1] == '.')
+        && (strncasecmp(test_realm + (size - trust_name_len), trust_name,
+                        trust_name_len) == 0)) {
+        return trust_name_len;
+    }
 
-	ipactx = ipadb_get_context(kcontext);
-	if (!ipactx || !ipactx->mspac) {
-		return KRB5_KDB_DBNOTINITED;
-	}
+    return 0;
+}
 
-	/* First, compare realm with ours, it would not be from a trusted realm then */
-	if (strncasecmp(test_realm, ipactx->realm, size) == 0) {
-		return KRB5_KDB_NOENTRY;
-	}
+/*
+ * The trusted domain test_realm belongs to, or NULL if none of them owns a
+ * matching name. Every name of every trusted domain is looked at once.
+ *
+ * The domain with the longest match wins, on equal length the first one in the
+ * list of trusts. A name matching all of test_realm ends the search, because no
+ * longer match exists. A subordinate name does not end it, because the list of
+ * trusts carries no order and a longer match may still follow.
+ */
+static const struct ipadb_adtrusts *
+ipadb_find_matching_trust(const struct ipadb_context *ipactx,
+                          const char *test_realm,
+                          size_t size)
+{
+    const struct ipadb_adtrusts *trust;
+    const struct ipadb_adtrusts *subordinate_trust = NULL;
+    size_t max_subordinate_len = 0;
+    size_t match_len;
+    size_t i;
+    size_t j;
 
-	if (!ipactx->mspac || !ipactx->mspac->trusts) {
-		return KRB5_KDB_NOENTRY;
-	}
+    for (i = 0; i < (size_t) ipactx->mspac->num_trusts; i++) {
+        trust = &ipactx->mspac->trusts[i];
 
-	/* Iterate through list of trusts and check if input realm belongs to any of the trust */
-	for(i = 0 ; i < ipactx->mspac->num_trusts ; i++) {
-		size_t len = 0;
-		result = strncasecmp(test_realm,
-				     ipactx->mspac->trusts[i].domain_name,
-				     size) == 0;
+        match_len = ipadb_trust_name_match_len(test_realm, size,
+                                               trust->domain_name,
+                                               strlen(trust->domain_name));
+        if (match_len == size) {
+            return trust;
+        }
+        if (match_len > max_subordinate_len) {
+            subordinate_trust = trust;
+            max_subordinate_len = match_len;
+        }
 
-		if (!result) {
-			len = strlen(ipactx->mspac->trusts[i].domain_name);
-			if ((size > len) && (test_realm[size - len - 1] == '.')) {
-				result = strncasecmp(test_realm + (size - len),
-						     ipactx->mspac->trusts[i].domain_name,
-						     len) == 0;
-			}
-		}
+        /* a NetBIOS name is flat, so only a complete match counts */
+        if (trust->flat_name != NULL) {
+            match_len = ipadb_trust_name_match_len(test_realm, size,
+                                                   trust->flat_name,
+                                                   strlen(trust->flat_name));
+            if (match_len == size) {
+                return trust;
+            }
+        }
 
-                if (!result && (ipactx->mspac->trusts[i].flat_name != NULL)) {
-			result = strncasecmp(test_realm,
-					     ipactx->mspac->trusts[i].flat_name,
-					     size) == 0;
-		}
+        for (j = 0; trust->upn_suffixes != NULL
+                    && trust->upn_suffixes[j] != NULL; j++) {
+            match_len = ipadb_trust_name_match_len(test_realm, size,
+                                                   trust->upn_suffixes[j],
+                                                   trust->upn_suffixes_len[j]);
+            if (match_len == size) {
+                return trust;
+            }
+            if (match_len > max_subordinate_len) {
+                subordinate_trust = trust;
+                max_subordinate_len = match_len;
+            }
+        }
+    }
 
-		if (!result && (ipactx->mspac->trusts[i].upn_suffixes != NULL)) {
-			for (j = 0; ipactx->mspac->trusts[i].upn_suffixes[j]; j++) {
-				result = strncasecmp(test_realm,
-						     ipactx->mspac->trusts[i].upn_suffixes[j],
-						     size) == 0;
-				if (!result) {
-					/* if UPN suffix did not match exactly, find if it is
-					 * superior to the test_realm, e.g. if test_realm ends
-					 * with the UPN suffix prefixed with dot*/
-					len = ipactx->mspac->trusts[i].upn_suffixes_len[j];
-					if ((size > len) && (test_realm[size - len - 1] == '.')) {
-						result = strncasecmp(test_realm + (size - len),
-								     ipactx->mspac->trusts[i].upn_suffixes[j],
-								     len) == 0;
-					}
-				}
-				if (result)
-					break;
-			}
-		}
+    return subordinate_trust;
+}
 
-		if (result) {
-			/* return the realm if caller supplied a place for it */
-			if (trusted_realm != NULL) {
-				name = (ipactx->mspac->trusts[i].parent_name != NULL) ?
-					ipactx->mspac->trusts[i].parent_name :
-					ipactx->mspac->trusts[i].domain_name;
-				length = strlen(name) + 1;
-				*trusted_realm = calloc(1, length);
-				if (*trusted_realm != NULL) {
-					for (j = 0; j < length; j++) {
-						(*trusted_realm)[j] = toupper(name[j]);
-					}
-				} else {
-					return KRB5_KDB_NOENTRY;
-				}
-			}
-			return 0;
-		}
-	}
+/*
+ * Checks whether a principal's realm belongs to one of the trusted domains,
+ * either by matching all of that domain's Kerberos realm, its NetBIOS name or
+ * one of its UPN suffixes, or by being subordinate to its realm or to one of
+ * its UPN suffixes. Returns the realm of that domain in 'trusted_realm', which
+ * is the forest root for a domain of a trusted forest.
+ * Returns 0 in case of success and KRB5_KDB_NOENTRY otherwise
+ * If DAL driver is not initialized, returns KRB5_KDB_DBNOTINITED
+ */
+krb5_error_code ipadb_is_princ_from_trusted_realm(krb5_context kcontext,
+                                                  const char *test_realm,
+                                                  size_t size,
+                                                  char **trusted_realm)
+{
+    struct ipadb_context *ipactx;
+    const struct ipadb_adtrusts *trust;
+    const char *name;
+    size_t realm_len;
+    size_t trusted_realm_len;
+    size_t j;
 
-	return KRB5_KDB_NOENTRY;
+    if (test_realm == NULL || size == 0 || test_realm[0] == '\0') {
+        return KRB5_KDB_NOENTRY;
+    }
+
+    ipactx = ipadb_get_context(kcontext);
+    if (ipactx == NULL || ipactx->mspac == NULL) {
+        return KRB5_KDB_DBNOTINITED;
+    }
+
+    /* our own realm is not a trusted realm; the length has to match too */
+    realm_len = strlen(ipactx->realm);
+    if (size == realm_len
+        && strncasecmp(test_realm, ipactx->realm, size) == 0) {
+        return KRB5_KDB_NOENTRY;
+    }
+
+    if (ipactx->mspac->trusts == NULL) {
+        return KRB5_KDB_NOENTRY;
+    }
+
+    trust = ipadb_find_matching_trust(ipactx, test_realm, size);
+    if (trust == NULL) {
+        return KRB5_KDB_NOENTRY;
+    }
+
+    /* return the realm if caller supplied a place for it */
+    if (trusted_realm != NULL) {
+        name = trust->parent_name != NULL
+               ? trust->parent_name
+               : trust->domain_name;
+
+        trusted_realm_len = strlen(name) + 1;
+        *trusted_realm = calloc(1, trusted_realm_len);
+        if (*trusted_realm == NULL) {
+            return KRB5_KDB_NOENTRY;
+        }
+
+        for (j = 0; j < trusted_realm_len; j++) {
+            (*trusted_realm)[j] = toupper((unsigned char) name[j]);
+        }
+    }
+
+    return 0;
 }
 
 static krb5_error_code

--- a/daemons/ipa-kdb/tests/ipa_kdb_tests.c
+++ b/daemons/ipa-kdb/tests/ipa_kdb_tests.c
@@ -76,6 +76,27 @@ struct test_ctx {
 #define TEST_REALM_TEMPLATE "some." SUFFIX_TEMPLATE
 #define EXTERNAL_REALM "WRONG.DOMAIN"
 
+/*
+ * Trusted domains for the matching tests. The overlapping pair reproduces two
+ * forests sharing a parent domain; the nested set has matching names at eight
+ * distinct lengths, so that no two names of different trusts are of equal
+ * length and every expectation is independent of the order of the trust list.
+ */
+#define OVERLAP_A_DOMAIN "forest.shared.test"
+#define OVERLAP_A_REALM "FOREST.SHARED.TEST"
+#define OVERLAP_B_DOMAIN "forestry.shared.test"
+#define OVERLAP_B_REALM "FORESTRY.SHARED.TEST"
+#define SHARED_PARENT "shared.test"
+/* a string prefix of the local realm EXAMPLE.COM that is no parent of it */
+#define LOCAL_REALM_PREFIX "EXAMPLE"
+
+struct trust_fixture {
+    const char *domain_name;
+    const char *flat_name;
+    const char *domain_sid;
+    const char *upn_suffixes[3];
+};
+
 static int setup(void **state)
 {
     int ret;
@@ -155,6 +176,133 @@ static int setup(void **state)
     *state = test_ctx;
 
     return 0;
+}
+
+/*
+ * Like setup(), but with a caller supplied list of trusted domains and only the
+ * fields ipadb_is_princ_from_trusted_realm() reads. teardown() is shared with
+ * setup().
+ */
+static int setup_trusts(void **state, const struct trust_fixture *defs,
+                        size_t num_trusts)
+{
+    krb5_context krb5_ctx;
+    krb5_error_code kerr;
+    struct ipadb_context *ipa_ctx;
+    struct test_ctx *test_ctx;
+    size_t i, j, num_suffixes;
+
+    kerr = krb5_init_context(&krb5_ctx);
+    assert_int_equal(kerr, 0);
+
+    kerr = krb5_set_default_realm(krb5_ctx, "EXAMPLE.COM");
+    assert_int_equal(kerr, 0);
+
+    kerr = krb5_db_setup_lib_handle(krb5_ctx);
+    assert_int_equal(kerr, 0);
+
+    ipa_ctx = calloc(1, sizeof(struct ipadb_context));
+    assert_non_null(ipa_ctx);
+
+    kerr = krb5_get_default_realm(krb5_ctx, &ipa_ctx->realm);
+    assert_int_equal(kerr, 0);
+
+    ipa_ctx->mspac = calloc(1, sizeof(struct ipadb_mspac));
+    assert_non_null(ipa_ctx->mspac);
+
+    /* make sure data is not read from LDAP */
+    ipa_ctx->mspac->last_update = time(NULL) - 1;
+
+    ipa_ctx->mspac->num_trusts = num_trusts;
+    ipa_ctx->mspac->trusts = calloc(num_trusts,
+                                    sizeof(struct ipadb_adtrusts));
+    assert_non_null(ipa_ctx->mspac->trusts);
+
+    for (i = 0; i < num_trusts; i++) {
+        struct ipadb_adtrusts *trust = &ipa_ctx->mspac->trusts[i];
+
+        trust->domain_name = strdup(defs[i].domain_name);
+        assert_non_null(trust->domain_name);
+        trust->flat_name = strdup(defs[i].flat_name);
+        assert_non_null(trust->flat_name);
+        trust->domain_sid = strdup(defs[i].domain_sid);
+        assert_non_null(trust->domain_sid);
+
+        for (num_suffixes = 0; defs[i].upn_suffixes[num_suffixes] != NULL;
+             num_suffixes++) {
+        }
+        if (num_suffixes == 0) {
+            continue;
+        }
+
+        trust->upn_suffixes = calloc(num_suffixes + 1, sizeof(char *));
+        assert_non_null(trust->upn_suffixes);
+        trust->upn_suffixes_len = calloc(num_suffixes, sizeof(size_t));
+        assert_non_null(trust->upn_suffixes_len);
+
+        for (j = 0; j < num_suffixes; j++) {
+            trust->upn_suffixes[j] = strdup(defs[i].upn_suffixes[j]);
+            assert_non_null(trust->upn_suffixes[j]);
+            trust->upn_suffixes_len[j] = strlen(trust->upn_suffixes[j]);
+        }
+    }
+
+    ipa_ctx->kcontext = krb5_ctx;
+    kerr = krb5_db_set_context(krb5_ctx, ipa_ctx);
+    assert_int_equal(kerr, 0);
+
+    test_ctx = talloc(NULL, struct test_ctx);
+    assert_non_null(test_ctx);
+
+    test_ctx->krb5_ctx = krb5_ctx;
+
+    *state = test_ctx;
+
+    return 0;
+}
+
+/* Two forests sharing a parent domain, which the first one owns as a UPN
+ * suffix while it is the parent of the second one's realm. The first one's
+ * realm is additionally a string prefix of the second one's, and the second
+ * one owns a UPN suffix that is a string prefix of the local realm. */
+static int setup_overlapping_trusts(void **state)
+{
+    static const struct trust_fixture defs[] = {
+        { OVERLAP_A_DOMAIN, "FOREST", "S-1-5-21-7-8-9",
+          { SHARED_PARENT, NULL } },
+        { OVERLAP_B_DOMAIN, "FORESTRY", "S-1-5-21-10-11-12",
+          { "example", NULL } },
+    };
+
+    return setup_trusts(state, defs, 2);
+}
+
+/*
+ * Trusted domains nested several levels deep:
+ *
+ *   A   realm a.test          UPN suffix test
+ *   B   realm b.a.test        UPN suffix deeper.c.b.a.test
+ *   C   realm c.b.a.test
+ *   D   realm d.test          UPN suffix deep.c.b.a.test
+ *   BB  realm bb.a.test
+ *
+ * B and BB differ in a way that only the dot boundary tells apart, and the UPN
+ * suffixes of B and D are deeper than the realm of C, so realms and suffixes
+ * have to compete by match length alone.
+ */
+static int setup_nested_trusts(void **state)
+{
+    static const struct trust_fixture defs[] = {
+        { "a.test",     "A",  "S-1-5-21-21-1-1", { "test", NULL } },
+        { "b.a.test",   "B",  "S-1-5-21-21-2-2",
+          { "deeper.c.b.a.test", NULL } },
+        { "c.b.a.test", "C",  "S-1-5-21-21-3-3", { NULL } },
+        { "d.test",     "D",  "S-1-5-21-21-4-4",
+          { "deep.c.b.a.test", NULL } },
+        { "bb.a.test",  "BB", "S-1-5-21-21-5-5", { NULL } },
+    };
+
+    return setup_trusts(state, defs, 5);
 }
 
 static int teardown(void **state)
@@ -492,6 +640,51 @@ static void test_dom_sid_string(void **state)
 }
 
 
+/* Resolve test_realm and assert that the expected trusted realm is returned. */
+static void assert_resolves_to(krb5_context krb5_ctx, const char *test_realm,
+                               const char *expected_realm)
+{
+    krb5_error_code kerr;
+    char *trusted_realm = NULL;
+
+    kerr = ipadb_is_princ_from_trusted_realm(krb5_ctx, test_realm,
+                                             strlen(test_realm),
+                                             &trusted_realm);
+    assert_int_equal(kerr, 0);
+    assert_non_null(trusted_realm);
+    assert_string_equal(trusted_realm, expected_realm);
+    free(trusted_realm);
+}
+
+/* Resolve test_realm and assert that it belongs to no trusted domain. */
+static void assert_resolves_to_nothing(krb5_context krb5_ctx,
+                                       const char *test_realm)
+{
+    krb5_error_code kerr;
+    char *trusted_realm = NULL;
+
+    kerr = ipadb_is_princ_from_trusted_realm(krb5_ctx, test_realm,
+                                             strlen(test_realm),
+                                             &trusted_realm);
+    assert_int_equal(kerr, KRB5_KDB_NOENTRY);
+    assert_null(trusted_realm);
+}
+
+/* Reverse the list of trusts, so that a lookup can be repeated with the trusts
+ * in the other order. */
+static void reverse_trusts(struct ipadb_context *ipa_ctx)
+{
+    struct ipadb_adtrusts swap;
+    size_t i, last;
+
+    for (i = 0; i < (size_t) ipa_ctx->mspac->num_trusts / 2; i++) {
+        last = (size_t) ipa_ctx->mspac->num_trusts - 1 - i;
+        swap = ipa_ctx->mspac->trusts[i];
+        ipa_ctx->mspac->trusts[i] = ipa_ctx->mspac->trusts[last];
+        ipa_ctx->mspac->trusts[last] = swap;
+    }
+}
+
 static void test_check_trusted_realms(void **state)
 {
     struct test_ctx *test_ctx;
@@ -522,6 +715,114 @@ static void test_check_trusted_realms(void **state)
                strlen(EXTERNAL_REALM),
                &trusted_realm);
     assert_int_equal(kerr, KRB5_KDB_NOENTRY);
+
+    /* The NetBIOS name resolves when it is the whole name that is tested. */
+    assert_resolves_to(test_ctx->krb5_ctx, FLAT_NAME, REALM);
+
+    /* A NetBIOS name is flat, so a name merely ending in it does not belong to
+     * the trust. */
+    assert_resolves_to_nothing(test_ctx->krb5_ctx, "host." FLAT_NAME);}
+
+static void check_overlapping_namespaces(krb5_context krb5_ctx)
+{
+    /* The realm of the second trust is the parent of nothing but matches
+     * completely, which beats the subordinate match on the UPN suffix of the
+     * first one. */
+    assert_resolves_to(krb5_ctx, OVERLAP_B_REALM, OVERLAP_B_REALM);
+    assert_resolves_to(krb5_ctx, OVERLAP_A_REALM, OVERLAP_A_REALM);
+
+    /* The UPN suffix resolves to the trust owning it, and so does a name below
+     * it that belongs to no trust of its own. */
+    assert_resolves_to(krb5_ctx, "SHARED.TEST", OVERLAP_A_REALM);
+    assert_resolves_to(krb5_ctx, "OTHER.SHARED.TEST", OVERLAP_A_REALM);
+
+    /* A name below both the UPN suffix of the first trust and the realm of the
+     * second one resolves to the second one, whose name is longer. */
+    assert_resolves_to(krb5_ctx, "SUB." OVERLAP_B_REALM, OVERLAP_B_REALM);
+    assert_resolves_to(krb5_ctx, "SUB." OVERLAP_A_REALM, OVERLAP_A_REALM);
+
+    /* A name sharing only its first characters with the local realm is not the
+     * local realm, so it resolves against the trusts like any other name. */
+    assert_resolves_to(krb5_ctx, LOCAL_REALM_PREFIX, OVERLAP_B_REALM);
+
+    assert_resolves_to_nothing(krb5_ctx, EXTERNAL_REALM);
+}
+
+static void test_check_trusted_realms_overlapping_namespaces(void **state)
+{
+    struct test_ctx *test_ctx;
+    struct ipadb_context *ipa_ctx;
+
+    test_ctx = (struct test_ctx *) *state;
+    ipa_ctx = ipadb_get_context(test_ctx->krb5_ctx);
+    assert_non_null(ipa_ctx);
+
+    check_overlapping_namespaces(test_ctx->krb5_ctx);
+    reverse_trusts(ipa_ctx);
+    check_overlapping_namespaces(test_ctx->krb5_ctx);
+}
+
+static void check_nested_namespaces(krb5_context krb5_ctx)
+{
+    /* a complete match at every level */
+    assert_resolves_to(krb5_ctx, "TEST", "A.TEST");
+    assert_resolves_to(krb5_ctx, "A.TEST", "A.TEST");
+    assert_resolves_to(krb5_ctx, "B.A.TEST", "B.A.TEST");
+    assert_resolves_to(krb5_ctx, "C.B.A.TEST", "C.B.A.TEST");
+    assert_resolves_to(krb5_ctx, "D.TEST", "D.TEST");
+    assert_resolves_to(krb5_ctx, "BB.A.TEST", "BB.A.TEST");
+
+    /* one level below each of them, the longest match has to win */
+    assert_resolves_to(krb5_ctx, "X.TEST", "A.TEST");
+    assert_resolves_to(krb5_ctx, "X.A.TEST", "A.TEST");
+    assert_resolves_to(krb5_ctx, "X.B.A.TEST", "B.A.TEST");
+    assert_resolves_to(krb5_ctx, "X.C.B.A.TEST", "C.B.A.TEST");
+    assert_resolves_to(krb5_ctx, "X.D.TEST", "D.TEST");
+
+    /* two and three levels below the deepest realm */
+    assert_resolves_to(krb5_ctx, "Y.X.C.B.A.TEST", "C.B.A.TEST");
+    assert_resolves_to(krb5_ctx, "Z.Y.X.C.B.A.TEST", "C.B.A.TEST");
+
+    /* a UPN suffix longer than any realm wins, and the realm of the trust
+     * owning it is returned rather than the suffix */
+    assert_resolves_to(krb5_ctx, "DEEP.C.B.A.TEST", "D.TEST");
+    assert_resolves_to(krb5_ctx, "X.DEEP.C.B.A.TEST", "D.TEST");
+
+    /* a UPN suffix of a trust high up beats the realm of a trust further down,
+     * so realms and suffixes compete by match length alone */
+    assert_resolves_to(krb5_ctx, "DEEPER.C.B.A.TEST", "B.A.TEST");
+    assert_resolves_to(krb5_ctx, "Z.DEEPER.C.B.A.TEST", "B.A.TEST");
+
+    /* the dot boundary decides: bb.a.test is not below b.a.test, and neither
+     * is a name below bb.a.test */
+    assert_resolves_to(krb5_ctx, "X.BB.A.TEST", "BB.A.TEST");
+
+    /* a NetBIOS name matches completely or not at all */
+    assert_resolves_to(krb5_ctx, "BB", "BB.A.TEST");
+    assert_resolves_to(krb5_ctx, "A", "A.TEST");
+    assert_resolves_to_nothing(krb5_ctx, "X.BB");
+    assert_resolves_to_nothing(krb5_ctx, "X.A");
+
+    /* a name cut short of a trusted domain's name is no match */
+    assert_resolves_to_nothing(krb5_ctx, "B.A.TES");
+    assert_resolves_to_nothing(krb5_ctx, "C.B.A.TES");
+    assert_resolves_to_nothing(krb5_ctx, "DEEP.C.B.A.TES");
+
+    assert_resolves_to_nothing(krb5_ctx, EXTERNAL_REALM);
+}
+
+static void test_check_trusted_realms_nested_namespaces(void **state)
+{
+    struct test_ctx *test_ctx;
+    struct ipadb_context *ipa_ctx;
+
+    test_ctx = (struct test_ctx *) *state;
+    ipa_ctx = ipadb_get_context(test_ctx->krb5_ctx);
+    assert_non_null(ipa_ctx);
+
+    check_nested_namespaces(test_ctx->krb5_ctx);
+    reverse_trusts(ipa_ctx);
+    check_nested_namespaces(test_ctx->krb5_ctx);
 }
 
 int main(int argc, const char *argv[])
@@ -536,6 +837,12 @@ int main(int argc, const char *argv[])
                                         setup, teardown),
         cmocka_unit_test_setup_teardown(test_check_trusted_realms,
                                         setup, teardown),
+        cmocka_unit_test_setup_teardown(
+                              test_check_trusted_realms_overlapping_namespaces,
+                              setup_overlapping_trusts, teardown),
+        cmocka_unit_test_setup_teardown(
+                                   test_check_trusted_realms_nested_namespaces,
+                                   setup_nested_trusts, teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
`ipadb_is_princ_from_trusted_realm()` iterated the list of trusted domains and returned on the first name that matched by any criterion. A trusted domain that merely owned a name the tested name was subordinate to could therefore win over another one whose realm matched the tested name completely, and which of the two won depended on the order the trusts were read from LDAP. With trusts to two AD forests where the first one has a UPN suffix registered that the second one's realm is subordinate to, the KDC refers the request to the first forest, which answers that the client is unknown.

Rank the candidates by how much of the tested name they match instead. `ipadb_trust_name_match_len()` measures one name of one trusted domain, returning the length it matches, and `ipadb_find_matching_trust()` picks the trust with the longest match. A name matching all of the tested name cannot be beaten and ends the search; a shorter match cannot end it, because the list of trusts carries no order and a longer match may still follow. Every name of every trusted domain is measured exactly once.

The comparisons are now length aware, which the ranking depends on: they were performed with `strncasecmp()` over the length of the tested name alone, so they also succeeded when the tested name was merely a prefix of a trusted domain's name. Without comparing the lengths, a prefix match cannot be told apart from a match of the whole name, so ranking the two cannot tell them apart either. The comparison against the local realm is made length aware for the same reason, so that a name sharing its first characters with the local realm is no longer taken for the local realm itself. The NetBIOS name keeps being compared for equality only, as nothing can be subordinate to a flat name.

Two unrelated corrections in the same function: the tested name is checked for a zero length before its first byte is read, and `toupper()` is passed an `unsigned char`.

Add tests with two trusted domains sharing a parent domain, and with five domains nested several levels deep. No two names that can match the same tested name are of equal length there, so every expectation is independent of the order of the list; both tests run twice, with the list reversed the second time. The pre-existing fixture has a single trusted domain, which is why the ambiguity was not observable.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10033

## Verification

None of this is covered by PR-CI.

**Unit tests.** Applied on their own against `release-4-13-1`, without the change to `ipa_kdb_mspac.c`, both new tests fail on the assertion they guard. With the full patch they pass, as do the five pre-existing ones.

**Referral on the wire.** A container with a real KDC, the topology from the issue as LDAP objects, and the plugin built twice from the same tree. Unpatched, the KDC refers to the domain that merely owns the UPN suffix; patched, to the domain whose realm matches. The plugin shipped with the image behaves like the unpatched build, so a released version is affected too.

**Order dependence.** Adding the same two trusted domains in the opposite order, same LDIF and same binaries, makes the unpatched plugin answer correctly. The patched one answers the same either way.

## Coverage

The new tests are cmocka tests in `daemons/ipa-kdb/tests/ipa_kdb_tests.c`, run via `make -C daemons/ipa-kdb check`. Gating builds and then runs pytest integration suites only, so they are not executed on a pull request.

`test_subordinate_suffix` in `ipatests/test_integration/test_trust.py` is unaffected: it uses a single trusted domain, so there is nothing to choose between. It runs in `nightly_latest`, not in `gating`.

## Attribution

The analysis, the reproduction and the measurements above are mine; the implementation was written with AI assistance and reviewed and tested by me line by line.

## Summary by Sourcery

Make principal realm trust resolution prefer the longest matching trusted domain name and handle incomplete or prefix matches correctly.

Bug Fixes:
- Ensure realms that fully match a trusted domain are chosen over domains that only own a subordinate UPN suffix, eliminating order-dependent referrals.
- Prevent misidentifying realms that merely share a prefix with the local realm or a NetBIOS name as trusted domains.
- Fix handling of zero-length test realm inputs and pass correctly typed characters to toupper().

Enhancements:
- Introduce length-aware matching logic for trusted realm, NetBIOS, and UPN suffix comparisons via helper routines.
- Centralize trusted domain selection in a dedicated function that evaluates all trust names once and ranks them by match length.

Tests:
- Add cmocka tests covering overlapping and deeply nested trusted domain namespaces and verifying order-independent trust selection for realm resolution.
- Extend trusted realm tests to cover flat NetBIOS name behavior, non-matching prefixes, and truncated domain names.