### PR TITLE
[Backport][ipa-4-13] dna plugin: use global configuration for replica communication

### DIFF
--- a/install/share/dna.ldif
+++ b/install/share/dna.ldif
@@ -15,6 +15,8 @@ dnaScope: $SUFFIX
 dnaThreshold: 500
 dnaSharedCfgDN: cn=posix-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
 dnaExcludeScope: cn=provisioning,$SUFFIX
+dnaRemoteBindMethod: SASL/GSSAPI
+dnaRemoteConnProtocol: LDAP
 
 dn: cn=Subordinate IDs,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config
 changetype: add
@@ -32,10 +34,11 @@ dnaThreshold: eval($SUBID_DNA_THRESHOLD)
 dnaSharedCfgDN: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
 dnaExcludeScope: cn=provisioning,$SUFFIX
 dnaInterval: eval($SUBID_COUNT)
+dnaRemoteBindMethod: SASL/GSSAPI
+dnaRemoteConnProtocol: LDAP
 
 # Enable the DNA plugin
 dn: cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config
 changetype: modify
 replace: nsslapd-pluginEnabled
 nsslapd-pluginEnabled: on
-

--- a/install/share/subid-generators.uldif
+++ b/install/share/subid-generators.uldif
@@ -19,6 +19,8 @@ default: dnaThreshold: eval($SUBID_DNA_THRESHOLD)
 default: dnaSharedCfgDN: cn=subordinate-ids,cn=dna,cn=ipa,cn=etc,$SUFFIX
 default: dnaExcludeScope: cn=provisioning,$SUFFIX
 default: dnaInterval: eval($SUBID_COUNT)
+default: dnaRemoteBindMethod: SASL/GSSAPI
+default: dnaRemoteConnProtocol: LDAP
 add: aci: (targetattr = "dnaNextRange || dnaNextValue || dnaMaxValue")(version 3.0;acl "permission:Modify DNA Range";allow (write) groupdn = "ldap:///cn=Modify DNA Range,cn=permissions,cn=pbac,$SUFFIX";)
 add: aci: (targetattr = "cn || dnaMaxValue || dnaNextRange || dnaNextValue  || dnaThreshold || dnaType || objectclass")(version 3.0;acl "permission:Read DNA Range";allow (read, search, compare) groupdn = "ldap:///cn=Read DNA Range,cn=permissions,cn=pbac,$SUFFIX";)
 

--- a/install/updates/40-replication.update
+++ b/install/updates/40-replication.update
@@ -39,3 +39,7 @@ default:member: cn=Replication Administrators,cn=privileges,cn=pbac,$SUFFIX
 
 dn: cn=masters,cn=ipa,cn=etc,$SUFFIX
 add:aci: (targetattr = "ipamaxdomainlevel || ipamindomainlevel")(version 3.0;acl "permission:Read domain level";allow (read, search, compare) groupdn = "ldap:///cn=Read domain level,cn=permissions,cn=pbac,$SUFFIX";)
+
+dn: cn=Posix IDs,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config
+default: dnaRemoteBindMethod: SASL/GSSAPI
+default: dnaRemoteConnProtocol: LDAP

--- a/ipaserver/install/plugins/update_dna_shared_config.py
+++ b/ipaserver/install/plugins/update_dna_shared_config.py
@@ -53,6 +53,11 @@ class update_dna_shared_config(Updater):
         else:
             logger.debug('Found DNA config %s', dna_config_base)
 
+        remote_bind_method = entry.single_value.get("dnaRemoteBindMethod")
+        if remote_bind_method is not None:
+            logger.error(
+                "dnaRemoteBindMethod is set on the global DNA entry already.")
+            return None
         sharedcfgdn = entry.single_value.get("dnaSharedCfgDN")
         if sharedcfgdn is not None:
             sharedcfgdn = DN(sharedcfgdn)

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -28,22 +28,32 @@ def _warning_already_exists(cls, member):
     )
 
 
+def _make_classdef(name):
+    """Build a ClassDef rooted in a throw-away Module.
+
+    astroid 3.x+ calls implicit_locals() during ClassDef.__init__, which
+    traverses parent links and asserts it reaches a Module node. Creating
+    the node via AstroidBuilder.string_build() gives it a proper parent
+    chain so that assertion passes.
+    """
+    module = AstroidBuilder(MANAGER).string_build(
+        "class {}: pass".format(name)
+    )
+    return module.body[0]
+
+
 def fake_class(name_or_class_obj, members=()):
     if isinstance(name_or_class_obj, scoped_nodes.ClassDef):
         cl = name_or_class_obj
     else:
-        cl = scoped_nodes.ClassDef(
-            name=name_or_class_obj, lineno=None, col_offset=None, parent=None,
-            end_lineno=None, end_col_offset=None)
+        cl = _make_classdef(name_or_class_obj)
 
     for m in members:
         if isinstance(m, str):
             if m in cl.locals:
                 _warning_already_exists(cl, m)
             else:
-                cl.locals[m] = [scoped_nodes.ClassDef(
-                    name=m, lineno=None, col_offset=None, parent=None,
-                    end_lineno=None, end_col_offset=None)]
+                cl.locals[m] = [_make_classdef(m)]
         elif isinstance(m, dict):
             for key, val in m.items():
                 assert isinstance(key, str), "key must be string"


### PR DESCRIPTION
This PR was opened automatically because PR #7273 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Adjust DNA plugin configuration handling and tooling compatibility for the ipa-4-13 backport.

Enhancements:
- Update pylint helper to construct temporary ClassDef nodes via AstroidBuilder for compatibility with astroid 3.x+.
- Add a guard in DNA shared configuration retrieval to detect and abort when dnaRemoteBindMethod is already set on the global DNA entry.