### PR TITLE
ipatests: extend ipa-cert-fix test coverage with customer scenarios

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -76,7 +76,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipa_cert_fix.py::TestIpaCertFix test_integration/test_ipa_cert_fix.py::TestIpaCertFixThirdParty
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 12000
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -151,7 +151,9 @@ class TestIpaCertFix(IntegrationTest):
         # Important: run_command with a str argument is able to
         # perform shell expansion but run_command with a list of
         # arguments is not
-        self.master.run_command('rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*')
+        self.master.run_command(
+            'rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*'
+        )
         tasks.uninstall_master(self.master)
         tasks.move_date(self.master, 'start', '-20Years-1day')
 
@@ -254,6 +256,18 @@ class TestIpaCertFix(IntegrationTest):
                                          raiseonerr=False)
         assert result.returncode == 2
 
+    def test_cert_fix_requires_root(self):
+        """
+        Test checks that ipa-cert-fix command fails to run
+        when invoked as a non-root user.
+        """
+        result = self.master.run_command(
+            ['runuser', '-u', 'nobody', '--', 'ipa-cert-fix'],
+            raiseonerr=False,
+        )
+        assert result.returncode == 1
+        assert 'Must be root to run ipa-cert-fix' in result.stderr_text
+
     def test_missing_startup(self, expire_cert_critical):
         """
         Test ipa-cert-fix fails/warns when startup directive is missing
@@ -322,6 +336,96 @@ class TestIpaCertFix(IntegrationTest):
         err_msg = ("CA signing cert is expired, exiting!")
         assert result.returncode == 1
         assert err_msg in result.stderr_text
+
+    def test_user_abort_on_prompt(self, expire_cert_critical):
+        """Test ipa-cert-fix aborts cleanly when user declines the prompt
+
+        When expired certs are detected but the user answers anything other
+        than 'yes' at the confirmation prompt, the tool must exit without
+        modifying any certificate or NSS database.
+
+        """
+        expire_cert_critical(self.master)
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        # 'no' = explicit decline, '\n' = empty Enter
+        for response in ('no\n', '\n'):
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v'],
+                stdin_text=response,
+            )
+            assert result.returncode == 0
+            assert "Not proceeding" in result.stdout_text
+
+        # Certs must remain unreachable: nothing was changed
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+    def test_certupdate_after_cert_fix(self, expire_cert_critical):
+        """Test ipa-certupdate succeeds and IPA services work after cert fix
+
+        After renewing expired certs with ipa-cert-fix, the documented
+        next step is to run ipa-certupdate to propagate the new certs to
+        all system services. IPA commands must work afterwards.
+        """
+        expire_cert_critical(self.master)
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        self.master.run_command(
+            ['ipa-cert-fix', '-v'], stdin_text='yes\n'
+        )
+        check_status(self.master, 9, "MONITORING")
+
+        # Propagate renewed certs to all system services
+        self.master.run_command(['ipa-certupdate'])
+
+        # Restart to verify services come up cleanly with new certs
+        self.master.run_command(['ipactl', 'restart'])
+
+        stdin = (
+            f"{self.master.config.admin_password}\n"
+            f"{self.master.config.admin_password}\n"
+            f"{self.master.config.admin_password}\n"
+        )
+        self.master.run_command(['kinit', 'admin'], stdin_text=stdin)
+
+        # Verify all services are running
+        result = self.master.run_command(['ipactl', 'status'])
+        assert result.returncode == 0
+
+        result = self.master.run_command(
+            ['ipa', 'user-find', 'admin']
+        )
+        assert 'User login: admin' in result.stdout_text
+
+    def test_cert_fix_ds_not_running(self, expire_cert_critical):
+        """Test ipa-cert-fix fails when Directory Server is stopped.
+
+        A common maintenance pattern is stopping dirsrv and then running
+        ipa-cert-fix without restarting it first.  The tool needs LDAP to
+        read the current cert state; a stopped DS must produce a clear
+        "cannot connect" error.
+        """
+        error_msg = 'The LDAP server is not running; cannot proceed'
+        expire_cert_critical(self.master)
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        instance = realm_to_serverid(self.master.domain.realm)
+        self.master.run_command(
+            ['systemctl', 'stop', 'dirsrv@%s' % instance]
+        )
+        try:
+            result = self.master.run_command(
+                ['ipa-cert-fix', '-v'],
+                stdin_text='yes\n',
+                raiseonerr=False,
+            )
+            assert result.returncode == 1
+            assert error_msg in result.stdout_text
+        finally:
+            # Always restart DS so fixture teardown can uninstall cleanly
+            self.master.run_command(
+                ['systemctl', 'start', 'dirsrv@%s' % instance]
+            )
 
 
 class TestIpaCertFixThirdParty(CALessBase):
@@ -549,3 +653,14 @@ class TestCertFixReplica(IntegrationTest):
             'Server-Cert cert-pki-ca'
         )
         assert renewed_expiry > initial_expiry
+
+        # Verify RA agent can authenticate to Dogtag on the replica
+        # after cert renewal. A disk vs LDAP serial mismatch would
+        # cause "Failed to authenticate to CA REST API".
+        stdin = (f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n")
+        self.replicas[0].run_command(
+            ['kinit', 'admin'], stdin_text=stdin
+        )
+        self.replicas[0].run_command(['ipa', 'cert-show', '1'])


### PR DESCRIPTION
Add new test cases covering documented recovery procedures and
common customer-reported failure scenarios for ipa-cert-fix:

TestIpaCertFix:
- test_cert_fix_requires_root: verify non-root invocation is rejected
- test_user_abort_on_prompt: verify clean abort when user declines
- test_certupdate_after_cert_fix: verify ipa-certupdate and IPA
  services work after cert renewal
- test_cert_fix_ds_not_running: verify clear error when DS is stopped

Signed-off-by: Sudhir Menon <sumenon@redhat.com>
Assisted-by : Claude <claude@noreply.com>

## Summary by Sourcery

Extend ipa-cert-fix integration testing to validate customer recovery scenarios and reliable behavior across supported IdM topologies.

Enhancements:
- Expand ipa-cert-fix integration coverage for documented recovery workflows and common operational failure scenarios across masters, replicas, KRA deployments, and CA-less replicas.

CI:
- Run the expanded ipa-cert-fix integration test suites in gating CI with an increased timeout.

Tests:
- Add integration tests covering privilege checks, user cancellation, post-renewal service validation, expired CA recovery, stopped Directory Server handling, KRA recovery, replica RA authentication consistency, and CA-less replica behavior.