### PR TITLE
ipatests: Add IPA-AD trust scenario for ipa-cert-fix tool

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -73,10 +73,10 @@ jobs:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_ipa_cert_fix.py::TestCertFixWithADTrust
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *ad_master

--- a/ipatests/test_integration/test_ipa_cert_fix.py
+++ b/ipatests/test_integration/test_ipa_cert_fix.py
@@ -549,3 +549,96 @@ class TestCertFixReplica(IntegrationTest):
             'Server-Cert cert-pki-ca'
         )
         assert renewed_expiry > initial_expiry
+
+
+class TestCertFixWithADTrust(IntegrationTest):
+    """Test ipa-cert-fix preserves AD trust after certificate renewal.
+
+    A common customer scenario: IPA server has an established trust with
+    Active Directory, certificates expire, and ipa-cert-fix is used to
+    recover. The trust relationship must remain functional after recovery.
+    """
+
+    num_ad_domains = 1
+
+    @classmethod
+    def install(cls, mh):
+        if not cls.master.transport.file_exists('/usr/bin/rpcclient'):
+            raise pytest.skip("Package samba-client not available "
+                              "on {}".format(cls.master.hostname))
+        tasks.install_master(cls.master, setup_dns=True,
+                             extra_args=['--no-ntp'])
+        cls.ad = cls.ads[0]
+        cls.ad_domain = cls.ad.domain.name
+        tasks.sync_time(cls.master, cls.ad)
+        tasks.install_adtrust(cls.master)
+        tasks.configure_dns_for_trust(cls.master, cls.ad)
+        tasks.establish_trust_with_ad(cls.master, cls.ad_domain)
+
+    @classmethod
+    def uninstall(cls, mh):
+        # Uninstall method is empty as the uninstallation is done in
+        # the fixture
+        pass
+
+    @pytest.fixture
+    def expire_and_restore(self):
+        """Expire certs, yield for test, then restore time and cleanup."""
+        tasks.move_date(self.master, 'stop', '+3Years+1day')
+        self.master.run_command(
+            ['ipactl', 'restart', '--ignore-service-failures']
+        )
+
+        yield
+
+        self.master.run_command(['systemctl', 'stop', 'certmonger'])
+        self.master.run_command(
+            'rm -fv ' + paths.CERTMONGER_REQUESTS_DIR + '*'
+        )
+        tasks.uninstall_master(self.master)
+        tasks.move_date(self.master, 'start', '-3Years-1day')
+
+    def test_cert_fix_preserves_trust(self, expire_and_restore):
+        """Test AD trust works after ipa-cert-fix recovery.
+
+        After ipa-cert-fix renews certs at the advanced time, we verify
+        trust at that time (certs are valid). We cannot move the date back
+        because renewed certs would become "not yet valid". AD user
+        resolution via cross-realm Kerberos is not testable due to the
+        clock skew between IPA (advanced) and AD (real time).
+
+        Steps:
+          1. Verify certs are expired (CA_UNREACHABLE)
+          2. Run ipa-cert-fix to renew all certs
+          3. Restart services (certs valid at advanced time)
+          4. Verify AD trust metadata is intact
+        """
+        # Step 1: confirm certs are expired
+        check_status(self.master, 8, "CA_UNREACHABLE")
+
+        # Step 2: fix the expired certs (ipa-cert-fix restarts services
+        # internally via ipactl restart)
+        self.master.run_command(['ipa-cert-fix', '-v'], stdin_text='yes\n')
+        check_status(self.master, 9, "MONITORING")
+
+        # Step 3: ensure services are fully running after cert renewal
+        self.master.run_command(['ipactl', 'restart'])
+
+        # Step 4: verify trust metadata is still intact
+        # Clear stale ccache and retry kinit — KDC/DS may need time
+        # to become fully operational after restart.
+        # Password provided 3 times: expired password after time shift
+        # prompts for old + new + confirm
+        self.master.run_command(['kdestroy', '-A'], raiseonerr=False)
+        stdin = (f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n"
+                 f"{self.master.config.admin_password}\n")
+        tasks.run_repeatedly(
+            self.master, ['kinit', 'admin'],
+            stdin_text=stdin, timeout=60
+        )
+
+        result = self.master.run_command(
+            ['ipa', 'trust-show', self.ad_domain]
+        )
+        assert self.ad_domain in result.stdout_text


### PR DESCRIPTION
TestCertFixWithADTrust
- test_cert_fix_preserves_trust: verify AD trust remains functional after cert renewal recovery

## Summary by Sourcery

Validate that certificate renewal recovery with ipa-cert-fix does not break established Active Directory trust relationships.

Enhancements:
- Add integration coverage confirming that ipa-cert-fix preserves an established Active Directory trust after recovering expired certificates.

CI:
- Run the new AD trust certificate-recovery scenario in the AD test topology with an extended timeout.

Tests:
- Add an integration test that establishes an IPA-AD trust, expires IPA certificates, runs ipa-cert-fix, and verifies the trust metadata remains available.