### PR TITLE
Spec file: bump samba version to 4.23.11 for Fedora < 44

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -104,7 +104,7 @@
 # Require 4.7.0 which brings Python 3 bindings
 # Require 4.12 which has DsRGetForestTrustInformation access rights fixes
 %if 0%{?fedora} < 44
-%global samba_version 2:4.23.10
+%global samba_version 2:4.23.11
 %else
 %global samba_version 2:4.24.5
 %endif


### PR DESCRIPTION
Update the required Samba version from 2:4.23.10 to 2:4.23.11 for Fedora releases older than 44.

See: https://packages.fedoraproject.org/pkgs/samba/samba/

## Summary by Sourcery

Enhancements:
- Update the Samba dependency for Fedora releases older than 44 to version 4.23.11.