### PR TITLE
[Backport][ipa-4-13] Spec file: bump samba version to 4.23.11 for Fedora < 44

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -104,7 +104,7 @@
 # Require 4.7.0 which brings Python 3 bindings
 # Require 4.12 which has DsRGetForestTrustInformation access rights fixes
 %if 0%{?fedora} < 44
-%global samba_version 2:4.23.10
+%global samba_version 2:4.23.11
 %else
 %global samba_version 2:4.24.5
 %endif


### PR DESCRIPTION
This PR was opened automatically because PR #8537 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Build:
- Bump the Samba package version in the FreeIPA spec for Fedora releases before 44 to 4.23.11.