### PR TITLE
ipatests: skip test_drop_privileges if run as unprivileged user

### DIFF
--- a/ipatests/test_ipaclient/test_epn.py
+++ b/ipatests/test_ipaclient/test_epn.py
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2026  FreeIPA Contributors see COPYING for license
 #
+import os
 
 import pytest
 import ipatests.util
@@ -11,6 +12,10 @@ from ipaclient.install.ipa_epn import drop_privileges
 from ipapython import admintool
 
 
+@pytest.mark.skipif(
+    os.geteuid() != 0,
+    reason="Must have root privileges to run this test",
+)
 @pytest.mark.parametrize(
     "user,group", [
         ("unknown_user", "daemon"),


### PR DESCRIPTION
https://codeberg.org/freeipa/freeipa/src/commit/b16f3b80dc5969c303ea71fe5d5080977d2c50c4/ipaclient/install/ipa_epn.py#L113-L118

`drop_privileges` does nothing if run as non-root while test `test_drop_privileges` expects it to raise an exception. So skip this test in unprivileged environments.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10035

## Summary by Sourcery

Avoid running the privilege-dropping test in unprivileged environments.

Bug Fixes:
- Skip the privilege-dropping test when the test process is not running as root, preventing failures in unprivileged environments.

Tests:
- Restrict the EPN privilege-dropping test to root-capable environments.