### PR TITLE
installer: check all the required PKI ports

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -505,8 +505,8 @@ def install_check(standalone, replica_config, options):
     if not options.external_cert_files:
         if not cainstance.check_ports():
             print(
-                "IPA requires ports 8080 and 8443 for PKI, but one or more "
-                "are currently in use."
+                "IPA requires ports 8005, 8009, 8080 and 8443 for PKI, but one "
+                "or more are currently in use."
             )
             raise ScriptError("Aborting installation")
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -87,11 +87,13 @@ ACME_CONFIG_FILES = (
 
 
 def check_ports():
-    """Check that dogtag ports (8080, 8443) are available.
+    """Check that dogtag ports (8005, 8009, 8080, 8443) are available.
 
     Returns True when ports are free, False if they are taken.
     """
     return all([ipautil.check_port_bindable(8443),
+                ipautil.check_port_bindable(8005),
+                ipautil.check_port_bindable(8009),
                 ipautil.check_port_bindable(8080)])
 
 


### PR DESCRIPTION
Internally (localhost only) PKI uses ports:
- 8005: the management port of the Tomcat instance
- 8009: the AJP port of the Tomcat instance
- 8080: the HTTP port of the Tomcat instance
- 8443: the HTTPS port of the Tomcat instance

But only the last two of them are actually checked on IPA installation.

In case some other process (e.g. another instance of tomcat) already listens on those ports, the IPA installer crashes without any helpful diagnostic:
```
DEBUG The ipa-server-install command failed, exception: RuntimeError: CA configuration failed.
ERROR CA configuration failed.
ERROR The ipa-server-install command failed. See /var/log/ipaserver-install.log for more information
```

PKI installation logs:
```
server[3407]: SEVERE: Failed to create server shutdown socket on address [localhost] and port [8005]
server[3407]: java.net.BindException: Address already in use
```

Gracefully fail installation with a helpful hint instead.

Similar issue:
https://pagure.io/freeipa/issue/7415

Fixes: https://codeberg.org/freeipa/freeipa/issues/10036

## Summary by Sourcery

Bug Fixes:
- Prevent IPA installation failures caused by occupied PKI ports by checking all required Tomcat ports before CA installation and reporting the ports to the user.