### PR TITLE
[Backport][ipa-4-13] Fix linters

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -2512,7 +2512,7 @@ output: PrimaryKey('value')
 command: host_add_delegation/1
 args: 2,4,3
 arg: Str('fqdn', cli_name='hostname')
-arg: Str('memberprincipal+', alwaysask=True, cli_name='principal')
+arg: Principal('memberprincipal+', alwaysask=True, cli_name='principal')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
@@ -2729,7 +2729,7 @@ output: PrimaryKey('value')
 command: host_remove_delegation/1
 args: 2,4,3
 arg: Str('fqdn', cli_name='hostname')
-arg: Str('memberprincipal+', alwaysask=True, cli_name='principal')
+arg: Principal('memberprincipal+', alwaysask=True, cli_name='principal')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
@@ -4798,7 +4798,7 @@ output: PrimaryKey('value')
 command: service_add_delegation/1
 args: 2,4,3
 arg: Principal('krbcanonicalname', cli_name='canonical_principal')
-arg: Str('memberprincipal+', alwaysask=True, cli_name='principal')
+arg: Principal('memberprincipal+', alwaysask=True, cli_name='principal')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
@@ -4998,7 +4998,7 @@ output: PrimaryKey('value')
 command: service_remove_delegation/1
 args: 2,4,3
 arg: Principal('krbcanonicalname', cli_name='canonical_principal')
-arg: Str('memberprincipal+', alwaysask=True, cli_name='principal')
+arg: Principal('memberprincipal+', alwaysask=True, cli_name='principal')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Flag('no_members', autofill=True, default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
@@ -5057,7 +5057,7 @@ args: 1,5,3
 arg: Str('cn', cli_name='delegation_name')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Flag('no_members', autofill=True, default=False)
-option: Str('principal*', alwaysask=True, cli_name='principals')
+option: Principal('principal*', alwaysask=True, cli_name='principals')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
@@ -5102,7 +5102,7 @@ args: 1,5,3
 arg: Str('cn', cli_name='delegation_name')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Flag('no_members', autofill=True, default=False)
-option: Str('principal*', alwaysask=True, cli_name='principals')
+option: Principal('principal*', alwaysask=True, cli_name='principals')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
@@ -5145,7 +5145,7 @@ command: servicedelegationtarget_add_member/1
 args: 1,4,3
 arg: Str('cn', cli_name='delegation_name')
 option: Flag('all', autofill=True, cli_name='all', default=False)
-option: Str('principal*', alwaysask=True, cli_name='principals')
+option: Principal('principal*', alwaysask=True, cli_name='principals')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
@@ -5177,7 +5177,7 @@ command: servicedelegationtarget_remove_member/1
 args: 1,4,3
 arg: Str('cn', cli_name='delegation_name')
 option: Flag('all', autofill=True, cli_name='all', default=False)
-option: Str('principal*', alwaysask=True, cli_name='principals')
+option: Principal('principal*', alwaysask=True, cli_name='principals')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('version?')
 output: Output('completed', type=[<type 'int'>])

--- a/doc/api/host_add_delegation.md
+++ b/doc/api/host_add_delegation.md
@@ -6,7 +6,7 @@ Add new resource delegation to a host
 |Name|Type|Required
 |-|-|-
 |fqdn|:ref:`Str<Str>`|True
-|memberprincipal|:ref:`Str<Str>`|True
+|memberprincipal|:ref:`Principal<Principal>`|True
 
 ### Options
 * all : :ref:`Flag<Flag>` **(Required)**

--- a/doc/api/host_remove_delegation.md
+++ b/doc/api/host_remove_delegation.md
@@ -6,7 +6,7 @@ Remove resource delegation from a host
 |Name|Type|Required
 |-|-|-
 |fqdn|:ref:`Str<Str>`|True
-|memberprincipal|:ref:`Str<Str>`|True
+|memberprincipal|:ref:`Principal<Principal>`|True
 
 ### Options
 * all : :ref:`Flag<Flag>` **(Required)**

--- a/doc/api/service_add_delegation.md
+++ b/doc/api/service_add_delegation.md
@@ -6,7 +6,7 @@ Add new resource delegation to a service
 |Name|Type|Required
 |-|-|-
 |krbcanonicalname|:ref:`Principal<Principal>`|True
-|memberprincipal|:ref:`Str<Str>`|True
+|memberprincipal|:ref:`Principal<Principal>`|True
 
 ### Options
 * all : :ref:`Flag<Flag>` **(Required)**

--- a/doc/api/service_remove_delegation.md
+++ b/doc/api/service_remove_delegation.md
@@ -6,7 +6,7 @@ Remove resource delegation from a service
 |Name|Type|Required
 |-|-|-
 |krbcanonicalname|:ref:`Principal<Principal>`|True
-|memberprincipal|:ref:`Str<Str>`|True
+|memberprincipal|:ref:`Principal<Principal>`|True
 
 ### Options
 * all : :ref:`Flag<Flag>` **(Required)**

--- a/doc/api/servicedelegationrule_add_member.md
+++ b/doc/api/servicedelegationrule_add_member.md
@@ -15,7 +15,7 @@ Add member to a named service delegation rule.
 * no_members : :ref:`Flag<Flag>` **(Required)**
  * Default: False
 * version : :ref:`Str<Str>`
-* principal : :ref:`Str<Str>`
+* principal : :ref:`Principal<Principal>`
 
 ### Output
 |Name|Type

--- a/doc/api/servicedelegationrule_remove_member.md
+++ b/doc/api/servicedelegationrule_remove_member.md
@@ -15,7 +15,7 @@ Remove member from a named service delegation rule.
 * no_members : :ref:`Flag<Flag>` **(Required)**
  * Default: False
 * version : :ref:`Str<Str>`
-* principal : :ref:`Str<Str>`
+* principal : :ref:`Principal<Principal>`
 
 ### Output
 |Name|Type

--- a/doc/api/servicedelegationtarget_add_member.md
+++ b/doc/api/servicedelegationtarget_add_member.md
@@ -13,7 +13,7 @@ Add member to a named service delegation target.
 * raw : :ref:`Flag<Flag>` **(Required)**
  * Default: False
 * version : :ref:`Str<Str>`
-* principal : :ref:`Str<Str>`
+* principal : :ref:`Principal<Principal>`
 
 ### Output
 |Name|Type

--- a/doc/api/servicedelegationtarget_remove_member.md
+++ b/doc/api/servicedelegationtarget_remove_member.md
@@ -13,7 +13,7 @@ Remove member from a named service delegation target.
 * raw : :ref:`Flag<Flag>` **(Required)**
  * Default: False
 * version : :ref:`Str<Str>`
-* principal : :ref:`Str<Str>`
+* principal : :ref:`Principal<Principal>`
 
 ### Output
 |Name|Type

--- a/ipapython/kerberos.py
+++ b/ipapython/kerberos.py
@@ -85,7 +85,10 @@ class Principal:
 
     def __eq__(self, other):
         if not isinstance(other, Principal):
-            return False
+            try:
+                other = Principal(other)
+            except TypeError:
+                return False
 
         return (self.components == other.components and
                 self.realm == other.realm)

--- a/ipatests/test_ipaserver/test_referer.py
+++ b/ipatests/test_ipaserver/test_referer.py
@@ -93,11 +93,11 @@ class test_referer(XMLRPC_test, Unauthorized_HTTP_test):
 
     def test_i18n_messages_valid(self):
         # i18n_messages requires a valid JSON request and we send
-        # nothing. If we get a 500 error then it got past the
+        # nothing. If we get a 400 error then it got past the
         # referer check.
         self.app_uri = "/ipa/i18n_messages"
         response = self._request()
-        assert_equal(response.status, 500, self.app_uri)
+        assert_equal(response.status, 400, self.app_uri)
 
     # /ipa/session/login_x509 is not tested yet as it requires
     # significant additional setup.


### PR DESCRIPTION
This PR was opened automatically because PR #8540 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Fix principal type documentation and comparison behavior, and align referer tests with the current API response.

Bug Fixes:
- Correct API documentation and generated API metadata to identify principal arguments with the Principal type.
- Update referer validation tests to expect the current bad-request response for malformed i18n requests.
- Allow Principal equality comparisons with values that can be converted to principals.

Documentation:
- Correct principal parameter types in delegation-related API documentation.

Tests:
- Align referer endpoint test expectations with its current response behavior.