### PR TITLE
kdb: enforce CNAME comparison against ipaOriginalUid in ID overrides

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac_trust.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac_trust.c
@@ -478,7 +478,7 @@ ipadb_check_trust_view_override(krb5_context context,
         goto end;
     }
 
-    uid_values = ldap_get_values_len(ipactx->lcontext, entry, "uid");
+    uid_values = ldap_get_values_len(ipactx->lcontext, entry, "ipaOriginalUid");
     if (!uid_values || !uid_values[0]) {
         *status = "TRUST_OVERRIDE_UID_UNDEFINED";
         kerr = EINVAL;


### PR DESCRIPTION
Kerberos principal of an Active Directory user is stored as ipaOriginalUid, not `uid`. `uid` value is POSIX username.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10041

## Summary by Sourcery

Bug Fixes:
- Compare ID override CNAME values against the user’s Kerberos principal stored in `ipaOriginalUid` rather than the POSIX `uid`, correcting Active Directory trust-view override validation.