### PR TITLE
ipatests: allow resolver restore after NetworkManager rewrite

### DIFF
--- a/ipatests/pytest_ipa/integration/resolver.py
+++ b/ipatests/pytest_ipa/integration/resolver.py
@@ -82,6 +82,14 @@ class Resolver(abc.ABC):
         """Checks if stack of backups is not empty"""
         return bool(self.backups)
 
+    def resync_state(self):
+        """Treat the host's current resolver config as expected.
+
+        Use when NetworkManager or IPA install/uninstall rewrote DNS
+        configuration outside Resolver, so restore() can proceed.
+        """
+        self.current_state = self._get_state()
+
     def check_state_expected(self):
         """Checks if resolver configuration has not changed.
 

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -1154,6 +1154,9 @@ def uninstall_master(host, ignore_topology_disconnect=True,
     host.run_command("find /run/ipa -name 'krb5*' | xargs rm -fv",
                      raiseonerr=False)
     while host.resolver.has_backups():
+        # Network Manager may rewrite resolv.conf during replica
+        # install/uninstall (RHEL)
+        host.resolver.resync_state()
         host.resolver.restore()
     if clean:
         unapply_fixes(host)
@@ -1163,6 +1166,9 @@ def uninstall_client(host):
     host.run_command(['ipa-client-install', '--uninstall', '-U'],
                      raiseonerr=False)
     while host.resolver.has_backups():
+        # Network Manager may rewrite resolv.conf during client
+        # install/uninstall (RHEL)
+        host.resolver.resync_state()
         host.resolver.restore()
     unapply_fixes(host)
 


### PR DESCRIPTION
On RHEL, NetworkManager may rewrite /etc/resolv.conf during replica or client uninstall. That makes uninstall_master/uninstall_client fail check_state_expected() even though IPA is already uninstalled. Accept the current resolver state before restore so teardown can put the backup back.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10061
## Summary by Sourcery

Make IPA test teardown tolerate NetworkManager resolver changes during replica and client uninstall.

Bug Fixes:
- Allow replica and client uninstall teardown to restore resolver backups even when NetworkManager rewrites the current resolver configuration.

CI:
- Update the temporary integration test job to run DNS location tests on a larger replica topology with an extended timeout.