### PR TITLE
[Backport][ipa-4-13] kdb: enforce CNAME comparison against ipaOriginalUid in ID overrides

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb_mspac_trust.c
+++ b/daemons/ipa-kdb/ipa_kdb_mspac_trust.c
@@ -478,7 +478,7 @@ ipadb_check_trust_view_override(krb5_context context,
         goto end;
     }
 
-    uid_values = ldap_get_values_len(ipactx->lcontext, entry, "uid");
+    uid_values = ldap_get_values_len(ipactx->lcontext, entry, "ipaOriginalUid");
     if (!uid_values || !uid_values[0]) {
         *status = "TRUST_OVERRIDE_UID_UNDEFINED";
         kerr = EINVAL;


### PR DESCRIPTION
This PR was opened automatically because PR #8545 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Bug Fixes:
- Ensure trust-view CNAME validation compares against the override’s original UID attribute.