### PR TITLE
ipa-join: increase argv array size for ipa-getkeytab

### DIFF
--- a/client/ipa-join.c
+++ b/client/ipa-join.c
@@ -1196,7 +1196,7 @@ join(const char *server, const char *hostname, const char *bindpw, const char *b
     }
 
     if (childpid == 0) {
-        char *argv[12];
+        char *argv[13];
         char *path = "/usr/sbin/ipa-getkeytab";
         int arg = 0;
         int err;


### PR DESCRIPTION
Make room for an additional argument by enlarging the argv array from 12 to 13 elements.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10044

## Summary by Sourcery

Bug Fixes:
- Prevent insufficient argument-array capacity when invoking ipa-getkeytab during host joining.