### PR TITLE
ipa-kdb: fix NULL pointer dereference when freeing credential type values

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -437,8 +437,10 @@ int ipadb_get_enc_salt_types(struct ipadb_context *ipactx,
 
 done:
     ldap_value_free_len(vals);
-    for (i = 0; i < c && cvals[i]; i++) {
-        free(cvals[i]);
+    if (cvals) {
+        for (i = 0; i < c && cvals[i]; i++) {
+            free(cvals[i]);
+        }
     }
     free(cvals);
     return ret;


### PR DESCRIPTION
Guard the loop that frees individual `cvals` entries with a NULL check before dereferencing the array.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10045

## Summary by Sourcery

Bug Fixes:
- Prevent a NULL pointer dereference when freeing credential type values in the IPA KDB module.