### PR TITLE
[Backport][ipa-4-13] installer: check all the required PKI ports

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -505,8 +505,8 @@ def install_check(standalone, replica_config, options):
     if not options.external_cert_files:
         if not cainstance.check_ports():
             print(
-                "IPA requires ports 8080 and 8443 for PKI, but one or more "
-                "are currently in use."
+                "IPA requires ports 8005, 8009, 8080 and 8443 for PKI, but one "
+                "or more are currently in use."
             )
             raise ScriptError("Aborting installation")
 

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -87,11 +87,13 @@ ACME_CONFIG_FILES = (
 
 
 def check_ports():
-    """Check that dogtag ports (8080, 8443) are available.
+    """Check that dogtag ports (8005, 8009, 8080, 8443) are available.
 
     Returns True when ports are free, False if they are taken.
     """
     return all([ipautil.check_port_bindable(8443),
+                ipautil.check_port_bindable(8005),
+                ipautil.check_port_bindable(8009),
                 ipautil.check_port_bindable(8080)])
 
 


### PR DESCRIPTION
This PR was opened automatically because PR #8542 was pushed to master and backport to ipa-4-13 is required.

## Summary by Sourcery

Bug Fixes:
- Ensure CA installation checks all required Dogtag PKI ports, including ports 8005 and 8009, before proceeding.