### PR TITLE
rpcserver: accept user@REALM in change_password

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -1281,7 +1281,11 @@ class change_password(Backend, HTTP_Status):
         result = 'error'
         policy_error = None
 
-        bind_dn = DN((self.api.Object.user.primary_key.name, data['user']),
+        user = data['user']
+        realm_suffix = '@' + self.api.env.realm
+        if user.upper().endswith(realm_suffix.upper()):
+            user = user[:-len(realm_suffix)]
+        bind_dn = DN((self.api.Object.user.primary_key.name, user),
                      self.api.env.container_user, self.api.env.basedn)
 
         try:


### PR DESCRIPTION
login_password already treats user@IPA.REALM as a principal, so the Web UI can prompt for an expired-password reset. change_password built the LDAP bind DN from the raw form field, so uid=user@REALM failed with invalid-password.

Fixes: https://github.com/freeipa/freeipa-webui/issues/1169

## Summary by Sourcery

Bug Fixes:
- Allow password changes to accept usernames in the user@REALM principal form by normalizing the realm suffix before binding.