### PR TITLE
Run ipa-client configuration update post-deployment

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -44,6 +44,19 @@ nodist_app_SCRIPTS =		\
 	certbot-dns-ipa		\
 	$(NULL)
 
+libexecipadir = $(libexecdir)/ipa
+nodist_libexecipa_SCRIPTS =	\
+	ipa-client-upgrade	\
+	$(NULL)
+
+ipa-client-upgrade: ipa-client-upgrade.in Makefile
+	$(AM_V_GEN)sed -e 's|@VERSION[@]|$(VERSION)|g' '$(srcdir)/$@.in' > $@
+	$(AM_V_GEN)chmod +x $@
+
+CLEANFILES =			\
+	ipa-client-upgrade	\
+	$(NULL)
+
 ipa_getkeytab_SOURCES =		\
 	ipa-getkeytab.c		\
 	ipa-client-common.c	\
@@ -110,6 +123,7 @@ EXTRA_DIST =			\
 	ipa-client-samba.in	\
 	ipa-epn.in              \
 	certbot-dns-ipa.in      \
+	ipa-client-upgrade.in   \
 	$(NULL)
 
 install-data-hook:

--- a/client/ipa-client-upgrade.in
+++ b/client/ipa-client-upgrade.in
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# ipa-client-upgrade - apply ipa-client configuration migrations to an
+# already-enrolled host after the ipa-client package has been upgraded.
+#
+# On package-mode systems this is invoked from the ipa-client %post
+# scriptlet. It is also invoked at boot by ipa-client-upgrade.service.
+
+# Version of the freeipa package this script was built from, substituted at
+# build time.
+VERSION="@VERSION@"
+
+SYSRESTORE=/var/lib/ipa-client/sysrestore
+STAMP="${SYSRESTORE}/.upgrade-version"
+
+# Only act on an enrolled client. sysrestore.index carries a header line plus
+# one line per restored file, so an enrolled host has at least 2 lines.
+restore=0
+if [ -f "${SYSRESTORE}/sysrestore.index" ]; then
+    restore=$(wc -l "${SYSRESTORE}/sysrestore.index" | awk '{print $1}')
+fi
+[ "$restore" -ge 2 ] || exit 0
+
+# Skip if the migrations for this version have already been applied.
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$VERSION" ]; then
+    exit 0
+fi
+
+if [ -f '/etc/sssd/sssd.conf' ]; then
+    if grep -E -q '/var/lib/sss/pubconf/krb5.include.d/' /etc/krb5.conf 2>/dev/null ; then
+        sed -i '\;includedir /var/lib/sss/pubconf/krb5.include.d;d' /etc/krb5.conf
+    fi
+fi
+
+if grep -E -q '\s*pkinit_anchors = FILE:/etc/ipa/ca.crt$' /etc/krb5.conf 2>/dev/null; then
+    sed -E 's|(\s*)pkinit_anchors = FILE:/etc/ipa/ca.crt$|\1pkinit_anchors = FILE:/var/lib/ipa-client/pki/kdc-ca-bundle.pem\n\1pkinit_pool = FILE:/var/lib/ipa-client/pki/ca-bundle.pem|' /etc/krb5.conf >/etc/krb5.conf.ipanew
+    mv -Z /etc/krb5.conf.ipanew /etc/krb5.conf
+    cp /etc/ipa/ca.crt /var/lib/ipa-client/pki/kdc-ca-bundle.pem
+    cp /etc/ipa/ca.crt /var/lib/ipa-client/pki/ca-bundle.pem
+fi
+
+/usr/bin/python3 -c 'from ipaclient.install.client import configure_krb5_snippet; configure_krb5_snippet()' >>/var/log/ipaupgrade.log 2>&1
+/usr/bin/python3 -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >>/var/log/ipaupgrade.log 2>&1
+chmod 0600 /var/log/ipaupgrade.log
+
+SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
+if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
+    if grep -E -q '^HostKeyAlgorithms ssh-rsa,ssh-dss' $SSH_CLIENT_SYSTEM_CONF 2>/dev/null; then
+        sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"
+    fi
+    # https://codeberg.org/freeipa/freeipa/issues/9536
+    # replace sss_ssh_knownhostsproxy with sss_ssh_knownhosts
+    if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then
+        if grep -E -q 'Include' $SSH_CLIENT_SYSTEM_CONF 2>/dev/null ; then
+            SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config.d/04-ipa.conf"
+        fi
+        sed -E --in-place=.orig 's/^(GlobalKnownHostsFile \/var\/lib\/sss\/pubconf\/known_hosts)$/# disabled by ipa-client update\n# \1/' $SSH_CLIENT_SYSTEM_CONF || :
+        sed -E --in-place=.orig 's/(ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p %p %h)/# replaced by ipa-client update\n    KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts %H/' $SSH_CLIENT_SYSTEM_CONF || :
+    fi
+fi
+
+UNBOUND_CFG=/etc/unbound/conf.d/zzz-ipa.conf
+if [ -f "$UNBOUND_CFG" ]; then
+    # The client has been configured for DoT: replace the line
+    #   tls-cert-bundle: /etc/pki/tls/certs/ca-bundle.crt
+    # with tls-system-cert: yes
+    # See https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile
+    if grep -E -q 'tls-cert-bundle: \/etc\/pki\/tls\/certs\/ca-bundle.crt' $UNBOUND_CFG 2>/dev/null; then
+        sed -E --in-place=.orig 's/tls-cert-bundle: \/etc\/pki\/tls\/certs\/ca-bundle.crt/tls-system-cert: yes/' $UNBOUND_CFG
+    fi
+fi
+
+echo "$VERSION" > "$STAMP"

--- a/client/systemd/Makefile.am
+++ b/client/systemd/Makefile.am
@@ -7,11 +7,18 @@ NULL =
 dist_noinst_DATA = 			\
 	ipa-epn.service.in		\
 	ipa-epn.timer.in		\
+	ipa-client-upgrade.service.in	\
 	$(NULL)
 
 systemdsystemunit_DATA = 	\
 	ipa-epn.service			\
 	ipa-epn.timer		\
+	ipa-client-upgrade.service	\
+	$(NULL)
+
+sssddropindir = $(systemdsystemunitdir)/sssd.service.d
+dist_sssddropin_DATA =			\
+	sssd-ipa-client-upgrade.conf	\
 	$(NULL)
 
 CLEANFILES = $(systemdsystemunit_DATA)

--- a/client/systemd/ipa-client-upgrade.service.in
+++ b/client/systemd/ipa-client-upgrade.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Update IPA client configuration after OS deployment
+Documentation=man:ipa-client-install(1)
+ConditionDirectoryNotEmpty=@localstatedir@/lib/ipa-client/sysrestore/
+After=local-fs.target
+# The migrations rewrite krb5/sssd/ssh/unbound configuration, so run before the
+# consumers of that configuration start.
+Before=sssd.service unbound.service
+
+[Service]
+Type=oneshot
+ExecStart=@libexecdir@/ipa/ipa-client-upgrade

--- a/client/systemd/sssd-ipa-client-upgrade.conf
+++ b/client/systemd/sssd-ipa-client-upgrade.conf
@@ -1,0 +1,4 @@
+# Pull the post-deployment ipa-client configuration update into the boot
+# transaction if sssd is enabled.
+[Unit]
+Wants=ipa-client-upgrade.service

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1470,57 +1470,10 @@ fi
 
 %post client
 %tmpfiles_create ipaclient.conf
-
+%systemd_post ipa-client-upgrade.service
 if [ $1 -gt 1 ] ; then
-    # Has the client been configured?
-    restore=0
-    test -f '/var/lib/ipa-client/sysrestore/sysrestore.index' && restore=$(wc -l '/var/lib/ipa-client/sysrestore/sysrestore.index' | awk '{print $1}')
-
-    if [ -f '/etc/sssd/sssd.conf' -a $restore -ge 2 ]; then
-        if grep -E -q '/var/lib/sss/pubconf/krb5.include.d/' /etc/krb5.conf  2>/dev/null ; then
-            sed -i '\;includedir /var/lib/sss/pubconf/krb5.include.d;d' /etc/krb5.conf
-        fi
-    fi
-
-    if [ $restore -ge 2 ]; then
-        if grep -E -q '\s*pkinit_anchors = FILE:/etc/ipa/ca.crt$' /etc/krb5.conf 2>/dev/null; then
-            sed -E 's|(\s*)pkinit_anchors = FILE:/etc/ipa/ca.crt$|\1pkinit_anchors = FILE:/var/lib/ipa-client/pki/kdc-ca-bundle.pem\n\1pkinit_pool = FILE:/var/lib/ipa-client/pki/ca-bundle.pem|' /etc/krb5.conf >/etc/krb5.conf.ipanew
-            mv -Z /etc/krb5.conf.ipanew /etc/krb5.conf
-            cp /etc/ipa/ca.crt /var/lib/ipa-client/pki/kdc-ca-bundle.pem
-            cp /etc/ipa/ca.crt /var/lib/ipa-client/pki/ca-bundle.pem
-        fi
-        %{__python3} -c 'from ipaclient.install.client import configure_krb5_snippet; configure_krb5_snippet()' >>/var/log/ipaupgrade.log 2>&1
-        %{__python3} -c 'from ipaclient.install.client import update_ipa_nssdb; update_ipa_nssdb()' >>/var/log/ipaupgrade.log 2>&1
-        chmod 0600 /var/log/ipaupgrade.log
-        SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config"
-        if [ -f "$SSH_CLIENT_SYSTEM_CONF" ]; then
-            if grep -E -q '^HostKeyAlgorithms ssh-rsa,ssh-dss' $SSH_CLIENT_SYSTEM_CONF 2>/dev/null; then
-                sed -E --in-place=.orig 's/^(HostKeyAlgorithms ssh-rsa,ssh-dss)$/# disabled by ipa-client update\n# \1/' "$SSH_CLIENT_SYSTEM_CONF"
-            fi
-            # https://codeberg.org/freeipa/freeipa/issues/9536
-            # replace sss_ssh_knownhostsproxy with sss_ssh_knownhosts
-            if [ -f '/usr/bin/sss_ssh_knownhosts' ]; then
-                if grep -E -q 'Include' $SSH_CLIENT_SYSTEM_CONF  2>/dev/null ; then
-                    SSH_CLIENT_SYSTEM_CONF="/etc/ssh/ssh_config.d/04-ipa.conf"
-                fi
-                sed -E --in-place=.orig 's/^(GlobalKnownHostsFile \/var\/lib\/sss\/pubconf\/known_hosts)$/# disabled by ipa-client update\n# \1/' $SSH_CLIENT_SYSTEM_CONF || :
-                sed -E --in-place=.orig 's/(ProxyCommand \/usr\/bin\/sss_ssh_knownhostsproxy -p \%p \%h)/# replaced by ipa-client update\n    KnownHostsCommand \/usr\/bin\/sss_ssh_knownhosts \%H/' $SSH_CLIENT_SYSTEM_CONF || :
-            fi
-        fi
-    fi
-
-    UNBOUND_CFG=/etc/unbound/conf.d/zzz-ipa.conf
-    if [ -f "$UNBOUND_CFG" -a $restore -ge 2 ]; then
-        # The client has been configured for Dot
-        # replace the line tls-cert-bundle: /etc/pki/tls/certs/ca-bundle.crt
-        # with tls-system-cert: yes
-        # See https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile
-        if grep -E -q 'tls-cert-bundle: \/etc\/pki\/tls\/certs\/ca-bundle.crt'  $UNBOUND_CFG 2>/dev/null; then
-            sed -E --in-place=.orig 's/tls-cert-bundle: \/etc\/pki\/tls\/certs\/ca-bundle.crt/tls-system-cert: yes/' $UNBOUND_CFG
-        fi
-    fi
+    /bin/systemctl start ipa-client-upgrade.service >/dev/null 2>&1 || :
 fi
-
 
 %if %{with selinux}
 # SELinux contexts are saved so that only affected files can be
@@ -1940,6 +1893,11 @@ fi
 %{_mandir}/man1/ipa-client-automount.1*
 %{_mandir}/man1/ipa-certupdate.1*
 %{_mandir}/man1/ipa-join.1*
+%dir %{_libexecdir}/ipa
+%attr(755,root,root) %{_libexecdir}/ipa/ipa-client-upgrade
+%attr(644,root,root) %{_unitdir}/ipa-client-upgrade.service
+%dir %{_unitdir}/sssd.service.d
+%attr(644,root,root) %{_unitdir}/sssd.service.d/sssd-ipa-client-upgrade.conf
 %dir %{_libexecdir}/ipa/acme
 %{_libexecdir}/ipa/acme/certbot-dns-ipa
 

--- a/ipatests/azure/azure_definitions/gating-fedora.yml
+++ b/ipatests/azure/azure_definitions/gating-fedora.yml
@@ -26,6 +26,12 @@ vms:
     tests:
     - test_integration/test_kerberos_flags.py
 
+  - container_job: client_upgrade_service
+    containers:
+      clients: 1
+    tests:
+    - test_integration/test_client_upgrade_service.py
+
   - container_job: forced_client_reenrollment
     containers:
       replicas: 1

--- a/ipatests/test_integration/test_client_upgrade_service.py
+++ b/ipatests/test_integration/test_client_upgrade_service.py
@@ -1,0 +1,138 @@
+#
+# Copyright (C) 2026  FreeIPA Contributors see COPYING for license
+#
+
+"""Tests for ipa-client-upgrade.service.
+
+The client configuration migrations that used to run only from the
+ipa-client %post scriptlet are driven by a Type=oneshot systemd unit,
+ipa-client-upgrade.service, so that they also run on image-mode
+(rpm-ostree) deployments where RPM scriptlets never run on the host.
+
+The unit is pulled into the boot transaction by an sssd.service drop-in
+(Wants=), guarded by ConditionDirectoryNotEmpty on the sysrestore
+directory, and short-circuited by a per-version stamp file so it is cheap
+to leave in place across every boot.
+"""
+
+from __future__ import absolute_import
+
+import os
+
+from ipaplatform.paths import paths
+from ipatests.test_integration.base import IntegrationTest
+from ipatests.pytest_ipa.integration import tasks
+
+UPGRADE_SERVICE = "ipa-client-upgrade.service"
+UPGRADE_STAMP = os.path.join(paths.IPA_CLIENT_SYSRESTORE, ".upgrade-version")
+SSSD_DROPIN = "sssd-ipa-client-upgrade.conf"
+KRB5_INCLUDEDIR = "includedir /var/lib/sss/pubconf/krb5.include.d/"
+
+
+class TestClientUpgradeService(IntegrationTest):
+    topology = 'line'
+    num_clients = 1
+
+    @property
+    def client(self):
+        return self.clients[0]
+
+    def _show(self, unit, prop):
+        """Return the value of a single systemd unit property."""
+        result = self.client.run_command(
+            ['systemctl', 'show', unit, '-p', prop, '--value']
+        )
+        return result.stdout_text.strip()
+
+    def _start(self):
+        """(Re)run the oneshot unit and return its Result."""
+        # reset-failed so a Result from a previous run does not linger
+        self.client.run_command(
+            ['systemctl', 'reset-failed', UPGRADE_SERVICE], raiseonerr=False
+        )
+        self.client.run_command(['systemctl', 'start', UPGRADE_SERVICE])
+        return self._show(UPGRADE_SERVICE, 'Result')
+
+    def _stamp_exists(self):
+        result = self.client.run_command(
+            ['test', '-f', UPGRADE_STAMP], raiseonerr=False
+        )
+        return result.returncode == 0
+
+    def test_unit_installed(self):
+        """The unit ships as a oneshot guarded on the sysrestore directory."""
+        unit = self.client.run_command(
+            ['systemctl', 'cat', UPGRADE_SERVICE]
+        ).stdout_text
+        assert 'Type=oneshot' in unit
+        assert 'ipa-client-upgrade' in unit
+        assert 'ConditionDirectoryNotEmpty' in unit
+
+    def test_dropin_wires_activation_from_sssd(self):
+        """The sssd.service drop-in pulls the unit into the boot transaction.
+
+        Activation must come from the drop-in rather than a preset so it
+        also takes effect on image-mode systems, where no enablement step
+        runs on the deployed host.
+        """
+        dropins = self._show('sssd.service', 'DropInPaths')
+        assert SSSD_DROPIN in dropins
+
+        wants = self._show('sssd.service', 'Wants')
+        assert UPGRADE_SERVICE in wants.split()
+
+    def test_unit_ordered_before_sssd(self):
+        """Migrations must run before the services that consume the config."""
+        before = self._show(UPGRADE_SERVICE, 'Before')
+        assert 'sssd.service' in before.split()
+
+    def test_service_runs_on_enrolled_client(self):
+        """On an enrolled client the unit runs and records the stamp."""
+        self.client.run_command(['rm', '-f', UPGRADE_STAMP])
+
+        assert self._start() == 'success'
+        assert self._stamp_exists()
+
+        stamp = self.client.get_file_contents(
+            UPGRADE_STAMP, encoding='utf-8'
+        ).strip()
+        assert stamp
+
+    def test_service_is_idempotent(self):
+        """A second run is a no-op short-circuited by the version stamp."""
+        before = self.client.get_file_contents(
+            UPGRADE_STAMP, encoding='utf-8'
+        ).strip()
+
+        assert self._start() == 'success'
+
+        after = self.client.get_file_contents(
+            UPGRADE_STAMP, encoding='utf-8'
+        ).strip()
+        assert after == before
+
+    def test_service_applies_migration(self):
+        """Running the unit performs the client configuration migration.
+
+        Inject the obsolete sssd krb5 includedir into krb5.conf, clear the
+        stamp so the migration runs, and confirm the unit removes it.
+        """
+        krb5 = self.client.get_file_contents(paths.KRB5_CONF, encoding='utf-8')
+        if KRB5_INCLUDEDIR not in krb5:
+            self.client.put_file_contents(
+                paths.KRB5_CONF, krb5 + "\n" + KRB5_INCLUDEDIR + "\n"
+            )
+        self.client.run_command(['rm', '-f', UPGRADE_STAMP])
+
+        assert self._start() == 'success'
+
+        krb5 = self.client.get_file_contents(paths.KRB5_CONF, encoding='utf-8')
+        assert KRB5_INCLUDEDIR not in krb5
+
+    def test_service_skipped_on_unenrolled_host(self):
+        """After uninstall the unit is a no-op: no migration, no stamp."""
+        tasks.uninstall_client(self.clients[0])
+        self.client.run_command(['rm', '-f', UPGRADE_STAMP])
+
+        assert self._start() == 'success'
+        assert not self._stamp_exists()

--- a/ipatests/test_integration/test_client_upgrade_service.py
+++ b/ipatests/test_integration/test_client_upgrade_service.py
@@ -129,18 +129,27 @@ class TestClientUpgradeService(IntegrationTest):
         Inject the obsolete sssd krb5 includedir into krb5.conf, clear the
         stamp so the migration runs, restart sssd to pull the unit in, and
         confirm the unit removed it.
+
+        krb5.conf is backed up and restored so a regression in the migration
+        cannot leave a broken Kerberos config for later tests on this host.
+        The includedir is prepended, where such top-level directives belong.
         """
-        krb5 = self.client.get_file_contents(paths.KRB5_CONF, encoding='utf-8')
-        if KRB5_INCLUDEDIR not in krb5:
-            self.client.put_file_contents(
-                paths.KRB5_CONF, krb5 + "\n" + KRB5_INCLUDEDIR + "\n"
+        with tasks.FileBackup(self.client, paths.KRB5_CONF):
+            krb5 = self.client.get_file_contents(
+                paths.KRB5_CONF, encoding='utf-8'
             )
-        self.client.run_command(['rm', '-f', UPGRADE_STAMP])
+            if KRB5_INCLUDEDIR not in krb5:
+                self.client.put_file_contents(
+                    paths.KRB5_CONF, KRB5_INCLUDEDIR + "\n" + krb5
+                )
+            self.client.run_command(['rm', '-f', UPGRADE_STAMP])
 
-        assert self._trigger_via_sssd() == 'success'
+            assert self._trigger_via_sssd() == 'success'
 
-        krb5 = self.client.get_file_contents(paths.KRB5_CONF, encoding='utf-8')
-        assert KRB5_INCLUDEDIR not in krb5
+            krb5 = self.client.get_file_contents(
+                paths.KRB5_CONF, encoding='utf-8'
+            )
+            assert KRB5_INCLUDEDIR not in krb5
 
     def test_service_skipped_on_unenrolled_host(self):
         """After uninstall the unit is a no-op: no migration, no stamp.

--- a/ipatests/test_integration/test_client_upgrade_service.py
+++ b/ipatests/test_integration/test_client_upgrade_service.py
@@ -44,8 +44,20 @@ class TestClientUpgradeService(IntegrationTest):
         )
         return result.stdout_text.strip()
 
-    def _start(self):
-        """(Re)run the oneshot unit and return its Result."""
+    def _trigger_via_sssd(self):
+        """Run the oneshot the way a deployed host does and return its Result.
+
+        Restarting sssd re-enqueues the Wants= dependency from the drop-in,
+        which pulls in the upgrade unit; the Before= ordering means the
+        restart does not return until the oneshot has finished. A plain
+        start of sssd would be a no-op here (it is already active) and would
+        not re-pull the dependency, so restart is required.
+        """
+        self.client.run_command(['systemctl', 'restart', 'sssd.service'])
+        return self._show(UPGRADE_SERVICE, 'Result')
+
+    def _start_unit(self):
+        """Run the oneshot directly and return its Result."""
         # reset-failed so a Result from a previous run does not linger
         self.client.run_command(
             ['systemctl', 'reset-failed', UPGRADE_SERVICE], raiseonerr=False
@@ -86,11 +98,11 @@ class TestClientUpgradeService(IntegrationTest):
         before = self._show(UPGRADE_SERVICE, 'Before')
         assert 'sssd.service' in before.split()
 
-    def test_service_runs_on_enrolled_client(self):
-        """On an enrolled client the unit runs and records the stamp."""
+    def test_service_runs_via_sssd_on_enrolled_client(self):
+        """Restarting sssd pulls in the unit, which records the stamp."""
         self.client.run_command(['rm', '-f', UPGRADE_STAMP])
 
-        assert self._start() == 'success'
+        assert self._trigger_via_sssd() == 'success'
         assert self._stamp_exists()
 
         stamp = self.client.get_file_contents(
@@ -104,7 +116,7 @@ class TestClientUpgradeService(IntegrationTest):
             UPGRADE_STAMP, encoding='utf-8'
         ).strip()
 
-        assert self._start() == 'success'
+        assert self._trigger_via_sssd() == 'success'
 
         after = self.client.get_file_contents(
             UPGRADE_STAMP, encoding='utf-8'
@@ -115,7 +127,8 @@ class TestClientUpgradeService(IntegrationTest):
         """Running the unit performs the client configuration migration.
 
         Inject the obsolete sssd krb5 includedir into krb5.conf, clear the
-        stamp so the migration runs, and confirm the unit removes it.
+        stamp so the migration runs, restart sssd to pull the unit in, and
+        confirm the unit removed it.
         """
         krb5 = self.client.get_file_contents(paths.KRB5_CONF, encoding='utf-8')
         if KRB5_INCLUDEDIR not in krb5:
@@ -124,15 +137,20 @@ class TestClientUpgradeService(IntegrationTest):
             )
         self.client.run_command(['rm', '-f', UPGRADE_STAMP])
 
-        assert self._start() == 'success'
+        assert self._trigger_via_sssd() == 'success'
 
         krb5 = self.client.get_file_contents(paths.KRB5_CONF, encoding='utf-8')
         assert KRB5_INCLUDEDIR not in krb5
 
     def test_service_skipped_on_unenrolled_host(self):
-        """After uninstall the unit is a no-op: no migration, no stamp."""
+        """After uninstall the unit is a no-op: no migration, no stamp.
+
+        sssd is unconfigured once the client is unenrolled, so this starts
+        the unit directly to confirm its own guard (the enrollment check and
+        ConditionDirectoryNotEmpty) short-circuits it.
+        """
         tasks.uninstall_client(self.clients[0])
         self.client.run_command(['rm', '-f', UPGRADE_STAMP])
 
-        assert self._start() == 'success'
+        assert self._start_unit() == 'success'
         assert not self._stamp_exists()


### PR DESCRIPTION
Move the client migration logic out of the %post scriptlet into ipa-client-upgrade, run via ipa-client-upgrade.service.

Fixes #9684

## Summary by Sourcery

Run IPA client configuration migrations through an ordered, idempotent systemd service after deployment.

New Features:
- Add a post-deployment client upgrade service that runs configuration migrations on enrolled clients, including image-mode deployments.

Bug Fixes:
- Ensure client configuration migrations are not limited to RPM installation scriptlets.

Enhancements:
- Trigger the upgrade service through the SSSD startup transaction, run it before SSSD, and make it idempotent with per-version stamping.

CI:
- Add Fedora gating coverage for the client upgrade service and its activation, ordering, migration, idempotence, and unenrolled-client behavior.

Tests:
- Add integration tests validating installation, SSSD drop-in activation, service ordering, migration execution, repeat-run behavior, and unenrolled-host handling.