### PR TITLE
ci: validate PKI PR 5338 (nightly_latest_pki)

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_latest_pki.yaml

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -39,7 +39,7 @@ jobs:
     job:
       class: Build
       args:
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
@@ -56,7 +56,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_simple_replication.py
         template: *ci-master-latest
         timeout: 3600
@@ -70,7 +70,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestExternalCA
         template: *ci-master-latest
         timeout: 4800
@@ -84,7 +84,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *ci-master-latest
         timeout: 3600
@@ -98,7 +98,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
         template: *ci-master-latest
         timeout: 3600
@@ -112,7 +112,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_vault.py
         template: *ci-master-latest
         timeout: 6300
@@ -126,7 +126,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_forced_client_reenrollment.py
         template: *ci-master-latest
         timeout: 4800
@@ -140,7 +140,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
         template: *ci-master-latest
         timeout: 10800
@@ -154,7 +154,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
         template: *ci-master-latest
         timeout: 10800
@@ -168,7 +168,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallCA
         template: *ci-master-latest
         timeout: 10800
@@ -182,7 +182,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
         template: *ci-master-latest
         timeout: 10800
@@ -196,7 +196,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
         template: *ci-master-latest
         timeout: 10800
@@ -210,7 +210,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
         template: *ci-master-latest
         timeout: 10800
@@ -224,7 +224,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
         template: *ci-master-latest
         timeout: 10800
@@ -238,7 +238,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
         template: *ci-master-latest
         timeout: 3600
@@ -252,7 +252,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
         template: *ci-master-latest
         timeout: 3600
@@ -266,7 +266,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
         template: *ci-master-latest
         timeout: 10800
@@ -280,7 +280,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
         template: *ci-master-latest
         timeout: 10800
@@ -294,7 +294,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMaster
         template: *ci-master-latest
         timeout: 10800
@@ -308,7 +308,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
         template: *ci-master-latest
         timeout: 10800
@@ -322,7 +322,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
         template: *ci-master-latest
         timeout: 10800
@@ -336,7 +336,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNSRepeatedly
         template: *ci-master-latest
         timeout: 10800
@@ -350,7 +350,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
         template: *ci-master-latest
         timeout: 10800
@@ -364,7 +364,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
         template: *ci-master-latest
         timeout: 3600
@@ -378,7 +378,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestServerInstall
         template: *ci-master-latest
         timeout: 12000
@@ -392,7 +392,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-latest
         timeout: 7200
@@ -406,7 +406,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestClientInstall
         template: *ci-master-latest
         timeout: 5400
@@ -421,7 +421,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestIPACommands
         template: *ci-master-latest
         timeout: 5400
@@ -435,7 +435,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestCertInstall
         template: *ci-master-latest
         timeout: 5400
@@ -449,7 +449,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestPKINIT
         template: *ci-master-latest
         timeout: 5400
@@ -463,7 +463,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
         template: *ci-master-latest
         timeout: 5400
@@ -477,7 +477,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
         template: *ci-master-latest
         timeout: 5400
@@ -491,7 +491,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
         template: *ci-master-latest
         timeout: 5400
@@ -505,7 +505,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
         template: *ci-master-latest
         timeout: 7200
@@ -519,7 +519,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
         template: *ci-master-latest
         timeout: 7200
@@ -533,7 +533,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
         template: *ci-master-latest
         timeout: 7200
@@ -547,7 +547,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
         template: *ci-master-latest
         timeout: 7200
@@ -561,7 +561,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
         template: *ci-master-latest
         timeout: 7200
@@ -575,7 +575,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
         template: *ci-master-latest
         timeout: 7200
@@ -589,7 +589,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *ci-master-latest
         timeout: 7200
@@ -603,7 +603,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
         template: *ci-master-latest
         timeout: 7200
@@ -617,7 +617,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_upgrade.py
         template: *ci-master-latest
         timeout: 7200
@@ -631,7 +631,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
         template: *ci-master-latest
         timeout: 7200
@@ -645,7 +645,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
         template: *ci-master-latest
         timeout: 7200
@@ -659,7 +659,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
         template: *ci-master-latest
         timeout: 10800
@@ -673,7 +673,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
         template: *ci-master-latest
         timeout: 10800
@@ -687,7 +687,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
         template: *ci-master-latest
         timeout: 7200
@@ -701,7 +701,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
         template: *ci-master-latest
         timeout: 7200
@@ -715,7 +715,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
         template: *ci-master-latest
         timeout: 10800
@@ -729,7 +729,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
         template: *ci-master-latest
         timeout: 7200
@@ -743,7 +743,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
         template: *ci-master-latest
         timeout: 7200
@@ -757,7 +757,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
         template: *ci-master-latest
         timeout: 7200
@@ -771,7 +771,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_uninstallation.py
         template: *ci-master-latest
         timeout: 7200
@@ -785,7 +785,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_webui/test_cert.py
         template: *ci-master-latest
         timeout: 2400
@@ -799,7 +799,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
@@ -815,7 +815,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_dns_locations.py
         template: *ci-master-latest
         timeout: 3600
@@ -829,7 +829,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
         template: *ci-master-latest
         timeout: 3600
@@ -843,7 +843,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
         template: *ci-master-latest
         timeout: 3600
@@ -857,7 +857,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
         template: *ci-master-latest
         timeout: 3600
@@ -871,7 +871,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
         timeout: 6300
@@ -885,7 +885,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
         template: *ci-master-latest
         timeout: 5400
@@ -899,7 +899,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_pkinit_install.py
         template: *ci-master-latest
         timeout: 3600
@@ -913,7 +913,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_pkinit_manage.py
         template: *ci-master-latest
         timeout: 3600
@@ -927,7 +927,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_crlgen_manage.py
         template: *ci-master-latest
         timeout: 3600
@@ -941,7 +941,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_ca_custom_sdn.py
         template: *ci-master-latest
         timeout: 7200
@@ -955,7 +955,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_fips.py
         template: *ci-master-latest
         timeout: 7200
@@ -969,7 +969,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: >-
             test_integration/test_acme.py::TestACME
             test_integration/test_acme.py::TestACMECALess
@@ -987,7 +987,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_acme.py::TestACMEPrune
         template: *ci-master-latest
         timeout: 3600
@@ -1001,7 +1001,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *ci-master-latest
         timeout: 10800
@@ -1015,7 +1015,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_idp.py
         template: *ci-master-latest
         timeout: 5000
@@ -1029,7 +1029,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestInstallWithCA_DNS1_RSN
         template: *ci-master-latest
         timeout: 10800
@@ -1043,7 +1043,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestInstallWithCA_KRA1_RSN
         template: *ci-master-latest
         timeout: 10800
@@ -1057,7 +1057,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestIPACommand_RSN
         template: *ci-master-latest
         timeout: 5400
@@ -1071,7 +1071,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: >-
             test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
             test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
@@ -1087,7 +1087,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
         template: *ci-master-latest
         timeout: 10800
@@ -1101,7 +1101,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
         template: *ci-master-latest
         timeout: 10800
@@ -1115,7 +1115,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-latest
         timeout: 6300
@@ -1129,7 +1129,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
         template: *ci-master-latest
         timeout: 6300
@@ -1143,7 +1143,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMInstallADTrustBase
         template: *ci-master-latest
         timeout: 5400
@@ -1157,7 +1157,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestADTrustInstallWithDNS_KRA_ADTrust
         template: *ci-master-latest
         timeout: 3600
@@ -1171,7 +1171,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMcertRenewal
         template: *ci-master-latest
         timeout: 3600
@@ -1185,7 +1185,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMCALessToExternalToSelfSignedCA
         template: *ci-master-latest
         timeout: 3600
@@ -1199,7 +1199,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMExternalToSelfSignedCA
         template: *ci-master-latest
         timeout: 3600
@@ -1213,7 +1213,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMcertFix
         template: *ci-master-latest
         timeout: 3600
@@ -1227,7 +1227,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMcertFixKRA
         template: *ci-master-latest
         timeout: 3600
@@ -1241,7 +1241,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMcertFixReplica
         template: *ci-master-latest
         timeout: 3600
@@ -1255,7 +1255,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMNegative
         template: *ci-master-latest
         timeout: 1800
@@ -1269,7 +1269,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMACME
         template: *ci-master-latest
         timeout: 3600
@@ -1283,7 +1283,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMBackupRestore
         template: *ci-master-latest
         timeout: 3600
@@ -1297,7 +1297,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMACMEPrune
         template: *ci-master-latest
         timeout: 3600
@@ -1311,7 +1311,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMVault
         template: *ci-master-latest
         timeout: 3600
@@ -1325,7 +1325,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: 'packit/dogtagpki-pki-5338'
+        copr: '@pki/master packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallKeySizes
         template: *ci-master-latest
         timeout: 3600

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -39,7 +39,7 @@ jobs:
     job:
       class: Build
       args:
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
@@ -56,7 +56,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_simple_replication.py
         template: *ci-master-latest
         timeout: 3600
@@ -70,7 +70,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestExternalCA
         template: *ci-master-latest
         timeout: 4800
@@ -84,7 +84,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
         template: *ci-master-latest
         timeout: 3600
@@ -98,7 +98,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestExternalCAProfileScenarios
         template: *ci-master-latest
         timeout: 3600
@@ -112,7 +112,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_vault.py
         template: *ci-master-latest
         timeout: 6300
@@ -126,7 +126,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_forced_client_reenrollment.py
         template: *ci-master-latest
         timeout: 4800
@@ -140,7 +140,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
         template: *ci-master-latest
         timeout: 10800
@@ -154,7 +154,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
         template: *ci-master-latest
         timeout: 10800
@@ -168,7 +168,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallCA
         template: *ci-master-latest
         timeout: 10800
@@ -182,7 +182,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
         template: *ci-master-latest
         timeout: 10800
@@ -196,7 +196,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
         template: *ci-master-latest
         timeout: 10800
@@ -210,7 +210,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
         template: *ci-master-latest
         timeout: 10800
@@ -224,7 +224,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
         template: *ci-master-latest
         timeout: 10800
@@ -238,7 +238,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
         template: *ci-master-latest
         timeout: 3600
@@ -252,7 +252,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
         template: *ci-master-latest
         timeout: 3600
@@ -266,7 +266,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
         template: *ci-master-latest
         timeout: 10800
@@ -280,7 +280,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
         template: *ci-master-latest
         timeout: 10800
@@ -294,7 +294,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMaster
         template: *ci-master-latest
         timeout: 10800
@@ -308,7 +308,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
         template: *ci-master-latest
         timeout: 10800
@@ -322,7 +322,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
         template: *ci-master-latest
         timeout: 10800
@@ -336,7 +336,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNSRepeatedly
         template: *ci-master-latest
         timeout: 10800
@@ -350,7 +350,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
         template: *ci-master-latest
         timeout: 10800
@@ -364,7 +364,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallwithSHA384withRSA
         template: *ci-master-latest
         timeout: 3600
@@ -378,7 +378,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestServerInstall
         template: *ci-master-latest
         timeout: 12000
@@ -392,7 +392,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
         template: *ci-master-latest
         timeout: 7200
@@ -406,7 +406,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestClientInstall
         template: *ci-master-latest
         timeout: 5400
@@ -421,7 +421,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestIPACommands
         template: *ci-master-latest
         timeout: 5400
@@ -435,7 +435,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestCertInstall
         template: *ci-master-latest
         timeout: 5400
@@ -449,7 +449,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestPKINIT
         template: *ci-master-latest
         timeout: 5400
@@ -463,7 +463,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
         template: *ci-master-latest
         timeout: 5400
@@ -477,7 +477,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
         template: *ci-master-latest
         timeout: 5400
@@ -491,7 +491,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
         template: *ci-master-latest
         timeout: 5400
@@ -505,7 +505,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
         template: *ci-master-latest
         timeout: 7200
@@ -519,7 +519,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
         template: *ci-master-latest
         timeout: 7200
@@ -533,7 +533,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
         template: *ci-master-latest
         timeout: 7200
@@ -547,7 +547,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
         template: *ci-master-latest
         timeout: 7200
@@ -561,7 +561,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
         template: *ci-master-latest
         timeout: 7200
@@ -575,7 +575,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
         template: *ci-master-latest
         timeout: 7200
@@ -589,7 +589,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
         template: *ci-master-latest
         timeout: 7200
@@ -603,7 +603,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
         template: *ci-master-latest
         timeout: 7200
@@ -617,7 +617,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_upgrade.py
         template: *ci-master-latest
         timeout: 7200
@@ -631,7 +631,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
         template: *ci-master-latest
         timeout: 7200
@@ -645,7 +645,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
         template: *ci-master-latest
         timeout: 7200
@@ -659,7 +659,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
         template: *ci-master-latest
         timeout: 10800
@@ -673,7 +673,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
         template: *ci-master-latest
         timeout: 10800
@@ -687,7 +687,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
         template: *ci-master-latest
         timeout: 7200
@@ -701,7 +701,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
         template: *ci-master-latest
         timeout: 7200
@@ -715,7 +715,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
         template: *ci-master-latest
         timeout: 10800
@@ -729,7 +729,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
         template: *ci-master-latest
         timeout: 7200
@@ -743,7 +743,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
         template: *ci-master-latest
         timeout: 7200
@@ -757,7 +757,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
         template: *ci-master-latest
         timeout: 7200
@@ -771,7 +771,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_uninstallation.py
         template: *ci-master-latest
         timeout: 7200
@@ -785,7 +785,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_webui/test_cert.py
         template: *ci-master-latest
         timeout: 2400
@@ -799,7 +799,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
@@ -815,7 +815,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_dns_locations.py
         template: *ci-master-latest
         timeout: 3600
@@ -829,7 +829,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
         template: *ci-master-latest
         timeout: 3600
@@ -843,7 +843,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert
         template: *ci-master-latest
         timeout: 3600
@@ -857,7 +857,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
         template: *ci-master-latest
         timeout: 3600
@@ -871,7 +871,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheck
         template: *ci-master-latest
         timeout: 6300
@@ -885,7 +885,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS test_integration/test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA test_integration/test_ipahealthcheck.py::TestIpaHealthCheckFileCheck
         template: *ci-master-latest
         timeout: 5400
@@ -899,7 +899,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_pkinit_install.py
         template: *ci-master-latest
         timeout: 3600
@@ -913,7 +913,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_pkinit_manage.py
         template: *ci-master-latest
         timeout: 3600
@@ -927,7 +927,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_crlgen_manage.py
         template: *ci-master-latest
         timeout: 3600
@@ -941,7 +941,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_ca_custom_sdn.py
         template: *ci-master-latest
         timeout: 7200
@@ -955,7 +955,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_fips.py
         template: *ci-master-latest
         timeout: 7200
@@ -969,7 +969,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: >-
             test_integration/test_acme.py::TestACME
             test_integration/test_acme.py::TestACMECALess
@@ -987,7 +987,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_acme.py::TestACMEPrune
         template: *ci-master-latest
         timeout: 3600
@@ -1001,7 +1001,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_ipa_cert_fix.py
         template: *ci-master-latest
         timeout: 10800
@@ -1015,7 +1015,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_idp.py
         template: *ci-master-latest
         timeout: 5000
@@ -1029,7 +1029,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestInstallWithCA_DNS1_RSN
         template: *ci-master-latest
         timeout: 10800
@@ -1043,7 +1043,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestInstallWithCA_KRA1_RSN
         template: *ci-master-latest
         timeout: 10800
@@ -1057,7 +1057,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestIPACommand_RSN
         template: *ci-master-latest
         timeout: 5400
@@ -1071,7 +1071,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: >-
             test_integration/test_random_serial_numbers.py::TestServerCALessToExternalCA_RSN
             test_integration/test_random_serial_numbers.py::TestInstall_RSN_MDB
@@ -1087,7 +1087,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestRSNPKIConfig
         template: *ci-master-latest
         timeout: 10800
@@ -1101,7 +1101,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_random_serial_numbers.py::TestRSNVault
         template: *ci-master-latest
         timeout: 10800
@@ -1115,7 +1115,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMInstall
         template: *ci-master-latest
         timeout: 6300
@@ -1129,7 +1129,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMInstallPasswordFile
         template: *ci-master-latest
         timeout: 6300
@@ -1143,7 +1143,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMInstallADTrustBase
         template: *ci-master-latest
         timeout: 5400
@@ -1157,7 +1157,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestADTrustInstallWithDNS_KRA_ADTrust
         template: *ci-master-latest
         timeout: 3600
@@ -1171,7 +1171,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMcertRenewal
         template: *ci-master-latest
         timeout: 3600
@@ -1185,7 +1185,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMCALessToExternalToSelfSignedCA
         template: *ci-master-latest
         timeout: 3600
@@ -1199,7 +1199,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMExternalToSelfSignedCA
         template: *ci-master-latest
         timeout: 3600
@@ -1213,7 +1213,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMcertFix
         template: *ci-master-latest
         timeout: 3600
@@ -1227,7 +1227,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMcertFixKRA
         template: *ci-master-latest
         timeout: 3600
@@ -1241,7 +1241,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMcertFixReplica
         template: *ci-master-latest
         timeout: 3600
@@ -1255,7 +1255,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMNegative
         template: *ci-master-latest
         timeout: 1800
@@ -1269,7 +1269,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMACME
         template: *ci-master-latest
         timeout: 3600
@@ -1283,7 +1283,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMBackupRestore
         template: *ci-master-latest
         timeout: 3600
@@ -1297,7 +1297,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMACMEPrune
         template: *ci-master-latest
         timeout: 3600
@@ -1311,7 +1311,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_hsm.py::TestHSMVault
         template: *ci-master-latest
         timeout: 3600
@@ -1325,7 +1325,7 @@ jobs:
       args:
         build_url: '{pki-fedora/build_url}'
         update_packages: True
-        copr: '@pki/master'
+        copr: 'packit/dogtagpki-pki-5338'
         test_suite: test_integration/test_installation.py::TestInstallKeySizes
         template: *ci-master-latest
         timeout: 3600


### PR DESCRIPTION
## Summary
Run the `nightly_latest_pki` PRCI job set against COPR `packit/dogtagpki-pki-5338` to validate a fresh IPA install with Dogtag PR 5338 (KeyConstraint / allowedKeys).

## Dogtag PR
https://github.com/dogtagpki/pki/pull/5338

## Changes
- `.freeipa-pr-ci.yaml` → `nightly_latest_pki.yaml`
- `copr: '@pki/master'` → `copr: 'packit/dogtagpki-pki-5338'`

## Test plan
- [ ] `pki-fedora/build` succeeds
- [ ] All `pki-fedora/*` RunPytest jobs green (see scenario doc for priority jobs)

## Summary by Sourcery

CI:
- Run the nightly latest-PKI PRCI validation suite against a dedicated COPR build containing the Dogtag PKI changes.