### PR TITLE
pylint: fix baseldap/privilege cyclic import

### DIFF
--- a/ipaserver/plugins/baseldap.py
+++ b/ipaserver/plugins/baseldap.py
@@ -1001,7 +1001,7 @@ last, after all sets and adds."""),
     enforce_managed_permission_operations = []
 
     def enforce_managed_permissions(self, *keys, **options):
-        from ipaserver.plugins.privilege import principal_has_privilege
+        from ipaserver.plugins.privilege_util import principal_has_privilege
         mp = getattr(self.obj, 'managed_permissions', None)
         if not mp:
             return

--- a/ipaserver/plugins/ca.py
+++ b/ipaserver/plugins/ca.py
@@ -15,7 +15,7 @@ from ipaserver.plugins.baseldap import (
     LDAPObject, LDAPSearch, LDAPCreate, LDAPDelete,
     LDAPUpdate, LDAPRetrieve, LDAPQuery, pkey_to_value)
 from ipaserver.plugins.cert import ca_enabled_check
-from ipaserver.plugins.privilege import principal_has_privilege
+from ipaserver.plugins.privilege_util import principal_has_privilege
 from ipalib.request import context
 from ipalib import _, ngettext, x509
 

--- a/ipaserver/plugins/certmap.py
+++ b/ipaserver/plugins/certmap.py
@@ -30,7 +30,7 @@ from ipalib.frontend import Object
 from ipalib.parameters import Bool, DNSNameParam, Flag, Int, Str, Certificate
 from ipalib.plugable import Registry
 from ipalib.request import context
-from ipaserver.plugins.privilege import principal_has_privilege
+from ipaserver.plugins.privilege_util import principal_has_privilege
 from .baseldap import (
     LDAPCreate,
     LDAPDelete,

--- a/ipaserver/plugins/certprofile.py
+++ b/ipaserver/plugins/certprofile.py
@@ -11,7 +11,7 @@ from .baseldap import (
     LDAPObject, LDAPSearch, LDAPCreate,
     LDAPDelete, LDAPUpdate, LDAPRetrieve)
 from .virtual import VirtualCommand
-from ipaserver.plugins.privilege import principal_has_privilege
+from ipaserver.plugins.privilege_util import principal_has_privilege
 from ipalib.request import context
 from ipalib import ngettext
 from ipalib.text import _

--- a/ipaserver/plugins/config.py
+++ b/ipaserver/plugins/config.py
@@ -37,7 +37,7 @@ from ipalib import _, messages
 from ipapython.admintool import ScriptError
 from ipapython.dn import DN
 from ipapython.ipavalidate import Email
-from ipaserver.plugins.privilege import principal_has_privilege
+from ipaserver.plugins.privilege_util import principal_has_privilege
 from ipaserver.install.adtrust import set_and_check_netbios_name
 from ipaserver.install.certs import validate_key_type_size
 

--- a/ipaserver/plugins/migration.py
+++ b/ipaserver/plugins/migration.py
@@ -31,7 +31,7 @@ from ipalib import Command, Password, Str, Flag, StrEnum, DNParam, Bool
 from ipalib.cli import to_cli
 from ipalib.plugable import Registry
 from ipalib.request import context
-from ipaserver.plugins.privilege import principal_has_privilege
+from ipaserver.plugins.privilege_util import principal_has_privilege
 from ipaserver.plugins.user import NO_UPG_MAGIC
 from ipalib import _
 from ipapython.dn import DN

--- a/ipaserver/plugins/privilege.py
+++ b/ipaserver/plugins/privilege.py
@@ -83,55 +83,6 @@ def validate_permission_to_privilege(api, permission):
                     'ipapermbindruletype', 'permission')})
 
 
-def principal_has_privilege(api, principal, privilege):
-    """
-    Validate that the principal is a member of the specified privilege.
-    If principal is None, use currently bound LDAP DN for validation.
-    cn=Directory Manager is explicitly allowed
-    """
-    privilege_dn = api.Object.privilege.get_dn(privilege)
-    ldap = api.Backend.ldap2
-    if principal is None:
-        dn_or_princ = DN(ldap.conn.whoami_s()[4:])
-        if dn_or_princ == DN('cn=Directory Manager'):
-            return True
-    else:
-        dn_or_princ = principal
-
-    # First try: Check if there is a principal that has the needed
-    # privilege.
-    filter = ldap.make_filter({
-        'krbprincipalname': dn_or_princ,
-        'memberof': privilege_dn},
-        rules=ldap.MATCH_ALL)
-    try:
-        ldap.find_entries(base_dn=api.env.basedn, filter=filter)
-        return True
-    except errors.NotFound:
-        pass
-
-    # Do not run ID override check for the user that has no Kerberos principal
-    if principal is None:
-        return False
-
-    # Second try: Check if there is an idoverride for the principal as
-    # ipaOriginalUid that has the needed privilege.
-    filter = ldap.make_filter(
-        {
-            'objectClass': ['ipaOverrideAnchor', 'nsmemberof'],
-            'ipaOriginalUid': principal,
-            'memberOf': privilege_dn
-        },
-        rules=ldap.MATCH_ALL)
-    _dn = DN(('cn', api.packages[0].idviews.DEFAULT_TRUST_VIEW_NAME),
-             api.env.container_views + api.env.basedn)
-    try:
-        ldap.find_entries(base_dn=_dn, filter=filter)
-    except errors.NotFound:
-        return False
-    return True
-
-
 @register()
 class privilege(LDAPObject):
     """

--- a/ipaserver/plugins/privilege_util.py
+++ b/ipaserver/plugins/privilege_util.py
@@ -1,0 +1,70 @@
+# Authors:
+#   Rob Crittenden <rcritten@redhat.com>
+#
+# Copyright (C) 2010  Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ipalib import errors
+from ipapython.dn import DN
+
+
+def principal_has_privilege(api, principal, privilege):
+    """
+    Validate that the principal is a member of the specified privilege.
+    If principal is None, use currently bound LDAP DN for validation.
+    cn=Directory Manager is explicitly allowed
+    """
+    privilege_dn = api.Object.privilege.get_dn(privilege)
+    ldap = api.Backend.ldap2
+    if principal is None:
+        dn_or_princ = DN(ldap.conn.whoami_s()[4:])
+        if dn_or_princ == DN('cn=Directory Manager'):
+            return True
+    else:
+        dn_or_princ = principal
+
+    # First try: Check if there is a principal that has the needed
+    # privilege.
+    filter = ldap.make_filter({
+        'krbprincipalname': dn_or_princ,
+        'memberof': privilege_dn},
+        rules=ldap.MATCH_ALL)
+    try:
+        ldap.find_entries(base_dn=api.env.basedn, filter=filter)
+        return True
+    except errors.NotFound:
+        pass
+
+    # Do not run ID override check for the user that has no Kerberos principal
+    if principal is None:
+        return False
+
+    # Second try: Check if there is an idoverride for the principal as
+    # ipaOriginalUid that has the needed privilege.
+    filter = ldap.make_filter(
+        {
+            'objectClass': ['ipaOverrideAnchor', 'nsmemberof'],
+            'ipaOriginalUid': principal,
+            'memberOf': privilege_dn
+        },
+        rules=ldap.MATCH_ALL)
+    _dn = DN(('cn', api.packages[0].idviews.DEFAULT_TRUST_VIEW_NAME),
+             api.env.container_views + api.env.basedn)
+    try:
+        ldap.find_entries(base_dn=_dn, filter=filter)
+    except errors.NotFound:
+        return False
+    return True

--- a/ipaserver/plugins/server.py
+++ b/ipaserver/plugins/server.py
@@ -31,7 +31,7 @@ from ipaserver import topology
 from ipaserver.servroles import ENABLED, HIDDEN
 from ipaserver.install import bindinstance, dnskeysyncinstance
 from ipaserver.install.service import hide_services, enable_services
-from ipaserver.plugins.privilege import principal_has_privilege
+from ipaserver.plugins.privilege_util import principal_has_privilege
 
 __doc__ = _("""
 IPA servers

--- a/ipaserver/plugins/trust.py
+++ b/ipaserver/plugins/trust.py
@@ -57,7 +57,7 @@ from ipaserver.dcerpc_common import (TRUST_ONEWAY,
                                      trust_type_string,
                                      trust_direction_string,
                                      trust_status_string)
-from ipaserver.plugins.privilege import principal_has_privilege
+from ipaserver.plugins.privilege_util import principal_has_privilege
 
 if six.PY3:
     unicode = str

--- a/ipaserver/plugins/vault.py
+++ b/ipaserver/plugins/vault.py
@@ -47,6 +47,16 @@ if api.env.in_server:
     from pki.crypto import AES_128_CBC_OID
     from pki import PKIException
 else:
+    import types
+    _key_client = types.SimpleNamespace(
+        KEY_STATUS_ACTIVE=object(),
+        KEY_STATUS_INACTIVE=object(),
+        PASS_PHRASE_TYPE=object(),
+    )
+    pki = types.SimpleNamespace(
+        account=types.SimpleNamespace(AccountClient=object),
+        key=types.SimpleNamespace(KeyClient=_key_client),
+    )
     DES_EDE3_CBC_OID = "{1 2 840 113549 3 7}"
     AES_128_CBC_OID = "{2 16 840 1 101 3 4 1 2}"
     PKIException = Exception
@@ -846,10 +856,8 @@ class vault_del(LDAPDelete):
         assert isinstance(dn, DN)
 
         with self.api.Backend.kra.get_client() as kra_client:
-            # pylint: disable=used-before-assignment
             kra_account = pki.account.AccountClient(kra_client.connection,
                                                     subsystem='kra')
-            # pylint: enable=used-before-assignment
             kra_account.login()
 
             client_key_id = self.obj.get_key_id(dn)


### PR DESCRIPTION
enforce_managed_permissions() imported principal_has_privilege from privilege.py, which already imports baseldap at module load time. Pylint reports R0401 (cyclic-import) and make lint exits with error 8 since fa2555cfd landed on master.

Move principal_has_privilege() to privilege_util.py. baseldap and privilege import it from there without creating a cycle.

Also stub the pki namespace in vault.py for the non-server branch, matching a65ebebd3, and drop the now-useless used-before-assignment suppression in vault_del.post_callback.

## Summary by Sourcery

Eliminate the baseldap and privilege cyclic import while keeping vault functionality lint-clean across non-server environments.

Bug Fixes:
- Resolve the Pylint cyclic-import error by moving privilege membership validation into a dependency-neutral utility module.

Enhancements:
- Update privilege checks across server plugins to use the shared utility.
- Provide a stubbed PKI namespace for non-server vault environments and remove the obsolete assignment-warning suppression.